### PR TITLE
chore: update better-sqlite3 to support npm 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     },
     "dependencies": {
         "apify-shared": "^0.6.3",
-        "better-sqlite3-with-prebuilds": "7.1.1",
+        "better-sqlite3-with-prebuilds": "7.1.5",
         "content-type": "^1.0.4",
         "fs-extra": "^9.1.0",
         "mime-types": "^2.1.29",


### PR DESCRIPTION
Updates the custom build of better-sqlite3 with latest version that should work fine in both NPM 6 & 7.

related: https://github.com/apify/apify-js/issues/952