### PR TITLE
add option to disable WAL mode for request queue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@apify/storage-local",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "description": "Drop in replacement of Apify API with a local SQLite and filesystem implementation. Not all API features are supported.",
     "engines": {
         "node": ">=10.17.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@apify/storage-local",
-    "version": "1.1.1",
+    "version": "1.1.0",
     "description": "Drop in replacement of Apify API with a local SQLite and filesystem implementation. Not all API features are supported.",
     "engines": {
         "node": ">=10.17.0"

--- a/src/database_connection_cache.ts
+++ b/src/database_connection_cache.ts
@@ -7,7 +7,7 @@ import Sqlite, { Database, Options } from 'better-sqlite3-with-prebuilds';
 export class DatabaseConnectionCache {
     private connections = new Map<string, Database>();
 
-    private useWalMode = true;
+    private enableWalMode: boolean | undefined;
 
     openConnection(path: string, options?: Options): Database {
         const existingConnection = this.connections.get(path);
@@ -58,11 +58,11 @@ export class DatabaseConnectionCache {
     //     });
     // }
 
-    disableWalMode(): void {
+    setWalMode(enableWalMode: boolean): void {
         if (this.connections.size) {
-            throw new Error('Cannot disable WAL mode while there are open database connections');
+            throw new Error(`Cannot ${enableWalMode ? 'enable' : 'disable'} WAL mode while there are open database connections`);
         }
-        this.useWalMode = false;
+        this.enableWalMode = enableWalMode;
     }
 
     private _createConnection(path: string, options?: Options): Database {
@@ -78,7 +78,7 @@ export class DatabaseConnectionCache {
         }
         // WAL mode should greatly improve performance
         // https://github.com/JoshuaWise/better-sqlite3/blob/master/docs/performance.md
-        if (this.useWalMode) connection.exec('PRAGMA journal_mode = WAL');
+        if (this.enableWalMode) connection.exec('PRAGMA journal_mode = WAL');
         connection.exec('PRAGMA foreign_keys = ON');
         return connection;
     }

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,9 @@ const databaseConnectionCache = new DatabaseConnectionCache();
  * @property {string} [storageDir='./apify_storage']
  *  Path to directory with storages. If there are no storages yet,
  *  appropriate sub-directories will be created in this directory.
+ * @property {boolean} [disableWalMode=false]
+ *  SQLite WAL mode (instead of a rollback journal) is used by default for request queues, however, in some file systems it could behave weirdly.
+ *  Setting this property to `true` will force the request queue database to use a rollback journal instead of WAL.
  */
 
 /**
@@ -33,10 +36,12 @@ class ApifyStorageLocal {
     constructor(options = {}) {
         ow(options, 'ApifyStorageLocalOptions', ow.optional.object.exactShape({
             storageDir: ow.optional.string,
+            disableWalMode: ow.optional.boolean,
         }));
 
         const {
             storageDir = './apify_storage',
+            disableWalMode = false,
         } = options;
 
         this.storageDir = storageDir;
@@ -44,6 +49,9 @@ class ApifyStorageLocal {
         this.keyValueStoreDir = path.resolve(storageDir, STORAGE_NAMES.KEY_VALUE_STORES);
         this.datasetDir = path.resolve(storageDir, STORAGE_NAMES.DATASETS);
         this.dbConnections = databaseConnectionCache;
+        this.disableWalMode = disableWalMode;
+
+        if (this.disableWalMode) this.dbConnections.disableWalMode();
 
         /**
          * DatasetClient keeps internal state: itemCount

--- a/src/index.js
+++ b/src/index.js
@@ -21,9 +21,9 @@ const databaseConnectionCache = new DatabaseConnectionCache();
  * @property {string} [storageDir='./apify_storage']
  *  Path to directory with storages. If there are no storages yet,
  *  appropriate sub-directories will be created in this directory.
- * @property {boolean} [disableWalMode=false]
+ * @property {boolean} [enableWalMode=true]
  *  SQLite WAL mode (instead of a rollback journal) is used by default for request queues, however, in some file systems it could behave weirdly.
- *  Setting this property to `true` will force the request queue database to use a rollback journal instead of WAL.
+ *  Setting this property to `false` will force the request queue database to use a rollback journal instead of WAL.
  */
 
 /**
@@ -36,12 +36,12 @@ class ApifyStorageLocal {
     constructor(options = {}) {
         ow(options, 'ApifyStorageLocalOptions', ow.optional.object.exactShape({
             storageDir: ow.optional.string,
-            disableWalMode: ow.optional.boolean,
+            enableWalMode: ow.optional.boolean,
         }));
 
         const {
             storageDir = './apify_storage',
-            disableWalMode = false,
+            enableWalMode = true,
         } = options;
 
         this.storageDir = storageDir;
@@ -49,9 +49,9 @@ class ApifyStorageLocal {
         this.keyValueStoreDir = path.resolve(storageDir, STORAGE_NAMES.KEY_VALUE_STORES);
         this.datasetDir = path.resolve(storageDir, STORAGE_NAMES.DATASETS);
         this.dbConnections = databaseConnectionCache;
-        this.disableWalMode = disableWalMode;
+        this.enableWalMode = enableWalMode;
 
-        if (this.disableWalMode) this.dbConnections.disableWalMode();
+        this.dbConnections.setWalMode(this.enableWalMode);
 
         /**
          * DatasetClient keeps internal state: itemCount


### PR DESCRIPTION
Kept var name as `useWalMode` in `DatabaseConnectionCache` as WAL mode is enabled by default, and if it's disabled - we simply skip enabling it. Seemed a bit misleading to name the var as `disableWalMode` here + TS does not like when method and variable name are the same.