### PR TITLE
chore: update apify-shared

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,8 +50,9 @@
         "build:watch": "tsc -b src -w"
     },
     "dependencies": {
-        "apify-shared": "^0.7.5",
-        "better-sqlite3-with-prebuilds": "7.1.8",
+        "@apify/consts": "^1.0.0",
+        "@apify/log": "^1.0.0",
+        "better-sqlite3-with-prebuilds": "^7.1.8",
         "content-type": "^1.0.4",
         "fs-extra": "^9.1.0",
         "mime-types": "^2.1.30",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 import { ensureDirSync, readdirSync } from 'fs-extra';
 import ow from 'ow';
 import { resolve } from 'path';
-import log from 'apify-shared/log';
-import { KEY_VALUE_STORE_KEYS } from 'apify-shared/consts';
+import log from '@apify/log';
+import { KEY_VALUE_STORE_KEYS } from '@apify/consts';
 import { STORAGE_NAMES, STORAGE_TYPES } from './consts';
 import { DatabaseConnectionCache } from './database_connection_cache';
 import { DatasetClient } from './resource_clients/dataset';

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,4 +1,4 @@
-import log from 'apify-shared/log';
+import log from '@apify/log';
 import { join } from 'path';
 import { ensureDirSync, statSync, writeFileSync } from 'fs-extra';
 import { ApifyStorageLocal } from '../src/index';


### PR DESCRIPTION
Updates `apify-shared` to use only the needed packages (`log` and `consts`).