### PR TITLE
fix: setWalMode with the same value does not throw

### DIFF
--- a/src/database_connection_cache.ts
+++ b/src/database_connection_cache.ts
@@ -59,6 +59,7 @@ export class DatabaseConnectionCache {
     // }
 
     setWalMode(enableWalMode: boolean): void {
+        if(this.enableWalMode === enableWalMode) return;
         if (this.connections.size) {
             throw new Error(`Cannot ${enableWalMode ? 'enable' : 'disable'} WAL mode while there are open database connections`);
         }


### PR DESCRIPTION
Even on a non-empty cache, if the call does not change the current WAL setting, the method doesn't throw.

fixes apify/apify-js#1305