### PR TITLE
fix: update better-sqlite3 and other dependencies

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,8 +5,9 @@
     },
     "overrides": [
         {
-            "files": ["src/**/*.ts"],
+            "files": ["*.ts"],
             "rules": {
+                "@typescript-eslint/no-explicit-any": "off",
                 "import/extensions": 0
             }
         }

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,19 +14,16 @@ jobs:
 
         strategy:
             matrix:
-                os: [ubuntu-latest, windows-latest]
-                node-version: [14, 16, 18]
+                os: [ ubuntu-latest ]
+                node-version: [ 14, 16, 18 ]
 
         steps:
-            -
-                uses: actions/checkout@v2
-            -
-                name: Use Node.js ${{ matrix.node-version }}
+            -   uses: actions/checkout@v3
+            -   name: Use Node.js ${{ matrix.node-version }}
                 uses: actions/setup-node@v1
                 with:
                     node-version: ${{ matrix.node-version }}
-            -
-                name: Cache Node Modules
+            -   name: Cache Node Modules
                 if: ${{ matrix.node-version == 16 }}
                 uses: actions/cache@v2
                 with:
@@ -34,33 +31,27 @@ jobs:
                         node_modules
                         build
                     key: cache-${{ github.run_id }}-v16
-            -
-                name: Install Dependencies
+            -   name: Install Dependencies
                 run: npm install
-            -
-                name: Run Tests
+            -   name: Run Tests
                 run: npm test
 
     lint:
         name: Lint
-        needs: [build_and_test]
+        needs: [ build_and_test ]
         runs-on: ubuntu-latest
 
         steps:
-            -
-                uses: actions/checkout@v2
-            -
-                name: Use Node.js 16
+            -   uses: actions/checkout@v3
+            -   name: Use Node.js 16
                 uses: actions/setup-node@v1
                 with:
                     node-version: 16
-            -
-                name: Load Cache
+            -   name: Load Cache
                 uses: actions/cache@v2
                 with:
                     path: |
                         node_modules
                         build
                     key: cache-${{ github.run_id }}-v16
-            -
-                run: npm run lint
+            -   run: npm run lint

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,12 +15,12 @@ jobs:
         strategy:
             matrix:
                 os: [ ubuntu-latest ]
-                node-version: [ 14, 16, 18 ]
+                node-version: [ 16, 18, 20 ]
 
         steps:
             -   uses: actions/checkout@v3
             -   name: Use Node.js ${{ matrix.node-version }}
-                uses: actions/setup-node@v1
+                uses: actions/setup-node@v3
                 with:
                     node-version: ${{ matrix.node-version }}
             -   name: Cache Node Modules
@@ -44,7 +44,7 @@ jobs:
         steps:
             -   uses: actions/checkout@v3
             -   name: Use Node.js 16
-                uses: actions/setup-node@v1
+                uses: actions/setup-node@v3
                 with:
                     node-version: 16
             -   name: Load Cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,12 +19,12 @@ jobs:
         strategy:
             matrix:
                 os: [ ubuntu-latest ]
-                node-version: [ 14, 16, 18 ]
+                node-version: [ 16, 18, 20 ]
 
         steps:
             -   uses: actions/checkout@v3
             -   name: Use Node.js ${{ matrix.node-version }}
-                uses: actions/setup-node@v1
+                uses: actions/setup-node@v3
                 with:
                     node-version: ${{ matrix.node-version }}
             -   name: Cache Node Modules
@@ -48,7 +48,7 @@ jobs:
         steps:
             -   uses: actions/checkout@v3
             -   name: Use Node.js 16
-                uses: actions/setup-node@v1
+                uses: actions/setup-node@v3
                 with:
                     node-version: 16
             -   name: Load Cache
@@ -69,7 +69,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   uses: actions/checkout@v3
-            -   uses: actions/setup-node@v1
+            -   uses: actions/setup-node@v3
                 with:
                     node-version: 16
                     registry-url: https://registry.npmjs.org/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,114 +1,98 @@
 name: Check & Release
 
 on:
-  # Push to master will deploy a beta version
-  push:
-    branches:
-      - master
-  # A release via GitHub releases will deploy a latest version
-  release:
-    types: [ published ]
+    # Push to master will deploy a beta version
+    push:
+        branches:
+            - master
+    # A release via GitHub releases will deploy a latest version
+    release:
+        types: [ published ]
 
 jobs:
-  # NPM install is done in a separate job and cached to speed up the following jobs.
-  build_and_test:
-    name: Build & Test
-    if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
-    runs-on: ${{ matrix.os }}
+    # NPM install is done in a separate job and cached to speed up the following jobs.
+    build_and_test:
+        name: Build & Test
+        if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
+        runs-on: ${{ matrix.os }}
 
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-        node-version: [14, 16, 18]
+        strategy:
+            matrix:
+                os: [ ubuntu-latest ]
+                node-version: [ 14, 16, 18 ]
 
-    steps:
-      -
-        uses: actions/checkout@v2
-      -
-        name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node-version }}
-      -
-        name: Cache Node Modules
-        if: ${{ matrix.node-version == 16 }}
-        uses: actions/cache@v2
-        with:
-          path: |
-            node_modules
-            build
-          key: cache-${{ github.run_id }}-v14
-      -
-        name: Install Dependencies
-        run: npm install
-      -
-        name: Run Tests
-        run: npm test
+        steps:
+            -   uses: actions/checkout@v3
+            -   name: Use Node.js ${{ matrix.node-version }}
+                uses: actions/setup-node@v1
+                with:
+                    node-version: ${{ matrix.node-version }}
+            -   name: Cache Node Modules
+                if: ${{ matrix.node-version == 16 }}
+                uses: actions/cache@v2
+                with:
+                    path: |
+                        node_modules
+                        build
+                    key: cache-${{ github.run_id }}-v14
+            -   name: Install Dependencies
+                run: npm install
+            -   name: Run Tests
+                run: npm test
 
-  lint:
-    name: Lint
-    needs: [build_and_test]
-    runs-on: ubuntu-latest
+    lint:
+        name: Lint
+        needs: [ build_and_test ]
+        runs-on: ubuntu-latest
 
-    steps:
-      -
-        uses: actions/checkout@v2
-      -
-        name: Use Node.js 16
-        uses: actions/setup-node@v1
-        with:
-          node-version: 16
-      -
-        name: Load Cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            node_modules
-            build
-          key: cache-${{ github.run_id }}-v14
-      -
-        run: npm run lint
+        steps:
+            -   uses: actions/checkout@v3
+            -   name: Use Node.js 16
+                uses: actions/setup-node@v1
+                with:
+                    node-version: 16
+            -   name: Load Cache
+                uses: actions/cache@v2
+                with:
+                    path: |
+                        node_modules
+                        build
+                    key: cache-${{ github.run_id }}-v14
+            -   run: npm run lint
 
 
-  # The deploy job is long but there are only 2 important parts. NPM publish
-  # and triggering of docker image builds in the apify-actor-docker repo.
-  deploy:
-    name: Publish to NPM
-    needs: [lint]
-    runs-on: ubuntu-latest
-    steps:
-      -
-        uses: actions/checkout@v2
-      -
-        uses: actions/setup-node@v1
-        with:
-          node-version: 16
-          registry-url: https://registry.npmjs.org/
-      -
-        name: Load Cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            node_modules
-            build
-          key: cache-${{ github.run_id }}-v14
-      -
-        # Determine if this is a beta or latest release
-        name: Set Release Tag
-        run: echo "RELEASE_TAG=$(if [ ${{ github.event_name }} = release ]; then echo latest; else echo beta; fi)" >> $GITHUB_ENV
-      -
-        # Check version consistency and increment pre-release version number for beta only.
-        name: Bump pre-release version
-        if: env.RELEASE_TAG == 'beta'
-        run: node ./.github/scripts/before-beta-release.js
-      -
+    # The deploy job is long but there are only 2 important parts. NPM publish
+    # and triggering of docker image builds in the apify-actor-docker repo.
+    deploy:
         name: Publish to NPM
-        run: NODE_AUTH_TOKEN=${{secrets.NPM_TOKEN}} npm publish --tag ${{ env.RELEASE_TAG }} --access public
-      -
-        # Latest version is tagged by the release process so we only tag beta here.
-        name: Tag Version
-        if: env.RELEASE_TAG == 'beta'
-        run: |
-          git_tag=v`node -p "require('./package.json').version"`
-          git tag $git_tag
-          git push origin $git_tag
+        needs: [ lint ]
+        runs-on: ubuntu-latest
+        steps:
+            -   uses: actions/checkout@v3
+            -   uses: actions/setup-node@v1
+                with:
+                    node-version: 16
+                    registry-url: https://registry.npmjs.org/
+            -   name: Load Cache
+                uses: actions/cache@v2
+                with:
+                    path: |
+                        node_modules
+                        build
+                    key: cache-${{ github.run_id }}-v14
+            - # Determine if this is a beta or latest release
+                name: Set Release Tag
+                run: echo "RELEASE_TAG=$(if [ ${{ github.event_name }} = release ]; then echo latest; else echo beta; fi)" >> $GITHUB_ENV
+            - # Check version consistency and increment pre-release version number for beta only.
+                name: Bump pre-release version
+                if: env.RELEASE_TAG == 'beta'
+                run: node ./.github/scripts/before-beta-release.js
+            -   name: Publish to NPM
+                run: NODE_AUTH_TOKEN=${{secrets.NPM_TOKEN}} npm publish --tag ${{ env.RELEASE_TAG }} --access public
+            - # Latest version is tagged by the release process so we only tag beta here.
+                name: Tag Version
+                if: env.RELEASE_TAG == 'beta'
+                run: |
+                    git_tag=v`node -p "require('./package.json').version"`
+                    git tag $git_tag
+                    git push origin $git_tag

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -11,7 +11,7 @@ export default async (): Promise<Config.InitialOptions> => ({
     testEnvironment: 'node',
     testRunner: 'jest-circus/runner',
     testTimeout: 5000,
-    collectCoverage: true,
+    // collectCoverage: true,
     collectCoverageFrom: [
         '**/src/**/*.ts',
         '**/src/**/*.js',

--- a/package.json
+++ b/package.json
@@ -50,30 +50,32 @@
         "build:watch": "tsc -b src -w"
     },
     "dependencies": {
-        "@apify/consts": "^1.10.0",
-        "@apify/log": "^1.2.3",
-        "better-sqlite3-with-prebuilds": "^7.4.3",
-        "content-type": "^1.0.4",
-        "fs-extra": "^10.1.0",
-        "json5": "^2.2.1",
+        "@apify/consts": "^2.15.0",
+        "@apify/log": "^2.2.18",
+        "@types/better-sqlite3": "^7.6.4",
+        "@types/integer": "^4.0.1",
+        "better-sqlite3": "^8.4.0",
+        "content-type": "^1.0.5",
+        "fs-extra": "^11.1.1",
+        "json5": "^2.2.3",
         "mime-types": "^2.1.35",
-        "ow": "^0.28.1",
-        "tslib": "^2.4.0"
+        "ow": "^0.28.2",
+        "tslib": "^2.5.2"
     },
     "devDependencies": {
-        "@apify/eslint-config-ts": "^0.2.3",
+        "@apify/eslint-config-ts": "^0.3.0",
         "@types/content-type": "^1.1.5",
-        "@types/fs-extra": "^9.0.13",
-        "@types/jest": "^27.5.1",
+        "@types/fs-extra": "^11.0.1",
+        "@types/jest": "^29.5.2",
         "@types/mime-types": "^2.1.1",
-        "@types/node": "^17.0.36",
-        "@typescript-eslint/eslint-plugin": "^5.26.0",
-        "@typescript-eslint/parser": "^5.26.0",
-        "eslint": "^8.16.0",
+        "@types/node": "^20.2.5",
+        "@typescript-eslint/eslint-plugin": "^5.59.8",
+        "@typescript-eslint/parser": "^5.59.8",
+        "eslint": "^8.41.0",
         "gen-esm-wrapper": "^1.1.3",
-        "jest": "^28.1.0",
-        "ts-jest": "^28.0.3",
-        "ts-node": "^10.8.0",
-        "typescript": "4.7.2"
+        "jest": "^29.5.0",
+        "ts-jest": "^29.1.0",
+        "ts-node": "^10.9.1",
+        "typescript": "5.1.3"
     }
 }

--- a/src/database_connection_cache.ts
+++ b/src/database_connection_cache.ts
@@ -1,4 +1,4 @@
-import Sqlite, { Database, Options } from 'better-sqlite3-with-prebuilds';
+import Sqlite, { Database, Options } from 'better-sqlite3';
 
 /**
  * SQLite prefers to have a single connection shared by

--- a/src/emulators/batch_add_requests/unprocessed_request.ts
+++ b/src/emulators/batch_add_requests/unprocessed_request.ts
@@ -1,6 +1,5 @@
 import { AllowedHttpMethods } from '../../resource_clients/request_queue';
 
 export class UnprocessedRequest {
-    // eslint-disable-next-line no-useless-constructor
     constructor(public uniqueKey: string, public url: string, public method?: AllowedHttpMethods) {}
 }

--- a/src/emulators/request_queue_emulator.ts
+++ b/src/emulators/request_queue_emulator.ts
@@ -1,5 +1,5 @@
 import { join, parse } from 'path';
-import type { Database, Statement, Transaction, RunResult } from 'better-sqlite3-with-prebuilds';
+import type { Database, Statement, Transaction, RunResult } from 'better-sqlite3';
 import { QueueOperationInfo } from './queue_operation_info';
 import { STORAGE_NAMES, TIMESTAMP_SQL, DATABASE_FILE_NAME } from '../consts';
 import type { DatabaseConnectionCache } from '../database_connection_cache';
@@ -138,7 +138,7 @@ export class RequestQueueEmulator {
                 WHERE id = ?
             `);
         }
-        return this._selectById.get(id);
+        return this._selectById.get(id) as RawQueueTableData;
     }
 
     deleteById(id: string): RunResult {
@@ -159,7 +159,7 @@ export class RequestQueueEmulator {
                 WHERE name = ?
             `);
         }
-        return this._selectByName.get(name);
+        return this._selectByName.get(name) as RawQueueTableData;
     }
 
     insertByName(name: string): RunResult {
@@ -184,7 +184,7 @@ export class RequestQueueEmulator {
                 return this.selectById(lastInsertRowid.toString());
             });
         }
-        return this._selectOrInsertTransaction(name);
+        return this._selectOrInsertTransaction(name) as RawQueueTableData;
     }
 
     selectModifiedAtById(id: string | number): string {
@@ -194,7 +194,7 @@ export class RequestQueueEmulator {
                 WHERE id = ?
             `).pluck();
         }
-        return this._selectModifiedAtById.get(id);
+        return this._selectModifiedAtById.get(id) as string;
     }
 
     updateNameById(id: string | number, name: string): RunResult {
@@ -253,7 +253,7 @@ export class RequestQueueEmulator {
                 WHERE queueId = CAST(:queueId as INTEGER) AND id = :id
             `).pluck();
         }
-        return this._selectRequestOrderNoByModel.get(requestModel);
+        return this._selectRequestOrderNoByModel.get(requestModel) as number;
     }
 
     selectRequestJsonByIdAndQueueId(requestId: string, queueId: string): string {
@@ -263,7 +263,7 @@ export class RequestQueueEmulator {
                 WHERE queueId = CAST(? as INTEGER) AND id = ?
             `).pluck();
         }
-        return this._selectRequestJsonByModel.get(queueId, requestId);
+        return this._selectRequestJsonByModel.get(queueId, requestId) as string;
     }
 
     selectRequestJsonsByQueueIdWithLimit(queueId: string, limit: number): string[] {
@@ -274,7 +274,7 @@ export class RequestQueueEmulator {
                 LIMIT ?
             `).pluck();
         }
-        return this._selectRequestJsonsByQueueIdWithLimit.all(queueId, limit);
+        return this._selectRequestJsonsByQueueIdWithLimit.all(queueId, limit) as string[];
     }
 
     insertRequestByModel(requestModel: RequestModel): RunResult {
@@ -340,7 +340,7 @@ export class RequestQueueEmulator {
                 }
             });
         }
-        return this._addRequestTransaction(requestModel);
+        return this._addRequestTransaction(requestModel) as QueueOperationInfo;
     }
 
     batchAddRequests(requestModels: RequestModel[]): BatchAddRequestsResult {
@@ -376,7 +376,7 @@ export class RequestQueueEmulator {
             });
         }
 
-        return this._addRequestsTransaction(requestModels);
+        return this._addRequestsTransaction(requestModels) as BatchAddRequestsResult;
     }
 
     updateRequest(requestModel: RequestModel): QueueOperationInfo {
@@ -408,7 +408,7 @@ export class RequestQueueEmulator {
                 return new QueueOperationInfo(model.id, orderNo);
             });
         }
-        return this._updateRequestTransaction(requestModel);
+        return this._updateRequestTransaction(requestModel) as QueueOperationInfo;
     }
 
     deleteRequest(id: string): unknown {

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,7 +84,6 @@ export class ApifyStorageLocal {
         const enableWalMode = bool(process.env.APIFY_LOCAL_STORAGE_ENABLE_WAL_MODE) ?? options.enableWalMode ?? true;
 
         if (!pathExistsSync(storageDir)) {
-            // eslint-disable-next-line max-len
             log.info(`Created a data storage folder at ${storageDir}. You can override the path by setting the APIFY_LOCAL_STORAGE_DIR environment variable`);
             ensureDirSync(storageDir);
         }
@@ -223,7 +222,7 @@ export class ApifyStorageLocal {
 
         const dirents = readdirSync(storageDir, { withFileTypes: true });
         for (const dirent of dirents) {
-            if (!dirent.isDirectory()) continue; // eslint-disable-line
+            if (!dirent.isDirectory()) continue;
 
             const innerStorageDir = resolve(storageDir, dirent.name);
 

--- a/src/resource_clients/key_value_store.ts
+++ b/src/resource_clients/key_value_store.ts
@@ -15,7 +15,6 @@ const streamFinished = util.promisify(stream.finished);
 
 export interface KeyValueStoreRecord {
     key: string;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     value: any;
     contentType?: string;
 }
@@ -268,7 +267,7 @@ export class KeyValueStoreClient {
                 const writeStream = value.pipe(createWriteStream(filePath));
                 await streamFinished(writeStream);
             } else {
-                await writeFile(filePath, value);
+                await writeFile(filePath, value as string);
             }
         } catch (err) {
             if (err.code === 'ENOENT') {
@@ -311,7 +310,6 @@ export class KeyValueStoreClient {
      * Returns an object when a file is found and handler executes successfully, undefined otherwise.
      * @private
      */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     private async _handleFile(key: string, handler: (...args: any[]) => unknown | Promise<unknown>) {
         for (const extension of COMMON_LOCAL_FILE_EXTENSIONS) {
             const fileName = `${key}.${extension}`;

--- a/test/datasets.test.ts
+++ b/test/datasets.test.ts
@@ -130,7 +130,7 @@ describe('pushItems', () => {
     const datasetName = 'first';
     const startCount = TEST_DATASETS[1].itemCount;
 
-    test('adds an object', async () => { /* eslint-disable no-shadow */
+    test('adds an object', async () => {
         const item = numToItem(startCount + 1);
 
         await storageLocal.dataset(datasetName).pushItems(item);

--- a/test/key_value_stores.test.ts
+++ b/test/key_value_stores.test.ts
@@ -99,7 +99,7 @@ describe('setRecord', () => {
     const storeName = 'first';
     const startCount = TEST_STORES[1].recordCount;
 
-    test('adds a value', async () => { /* eslint-disable no-shadow */
+    test('adds a value', async () => {
         const record = numToRecord(startCount + 1);
 
         await storageLocal.keyValueStore(storeName).setRecord(stripRecord(record));


### PR DESCRIPTION
We were depending on a custom better-sqlite3 version with more prebuilds, but better-sqlite3 now apparently provides all the prebuilds we need, so this PR uses that directly.