### PR TITLE
feat: implement `KeyValueStore.recordExists`

### DIFF
--- a/src/resource_clients/key_value_store.ts
+++ b/src/resource_clients/key_value_store.ts
@@ -190,6 +190,22 @@ export class KeyValueStoreClient {
         };
     }
 
+    /**
+     * Tests whether a record with the given key exists in the key-value store without retrieving its value.
+     * @param key The queried record key.
+     * @returns `true` if the record exists, `false` otherwise.
+     */
+    async recordExists(key: string): Promise<boolean> {
+        ow(key, ow.string);
+        try {
+            const result = await this._handleFile(key, stat);
+            return !!result;
+        } catch (err) {
+            if (err.code === 'ENOENT') return false;
+            throw new Error(`Error checking file '${key}' in directory '${this.storeDir}'.\nCause: ${err.message}`);
+        }
+    }
+
     async getRecord(key: string, options: KeyValueStoreClientGetRecordOptions = {}): Promise<KeyValueStoreRecord | undefined> {
         ow(key, ow.string);
         ow(options, ow.object.exactShape({

--- a/test/key_value_stores.test.ts
+++ b/test/key_value_stores.test.ts
@@ -204,6 +204,27 @@ describe('setRecord', () => {
     });
 });
 
+describe('recordExists', () => {
+    const storeName = 'first';
+    const startCount = TEST_STORES[1].recordCount;
+
+    test('retruns true for existing records', async () => {
+        let savedRecord = numToRecord(3);
+        let record = await storageLocal.keyValueStore(storeName).recordExists(savedRecord.key);
+        expect(record).toBeTruthy();
+
+        savedRecord = numToRecord(30);
+        record = await storageLocal.keyValueStore('second').recordExists(savedRecord.key);
+        expect(record).toBeTruthy();
+    });
+
+    test('returns false for non-existent records', async () => {
+        const savedRecord = numToRecord(startCount + 1);
+        const record = await storageLocal.keyValueStore('first').recordExists(savedRecord.key);
+        expect(record).toBeFalsy();
+    });
+});
+
 describe('getRecord', () => {
     const storeName = 'first';
     const startCount = TEST_STORES[1].recordCount;


### PR DESCRIPTION
Implements `KeyValueStore.recordExists` (see https://github.com/apify/crawlee/pull/2339).