### PR TITLE
fix: resolved an issue where types were not being properly picked up in some ESM TS projects (resolves #62)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,13 +7,19 @@
     },
     "main": "dist/index.js",
     "module": "dist/index.mjs",
-    "types": "dist/index.d.ts",
     "exports": {
         ".": {
-            "import": "./dist/index.mjs",
-            "require": "./dist/index.js"
+            "import": {
+                "types": "./dist/index.d.ts",
+                "default": "./dist/index.mjs"
+            },
+            "require": {
+                "types": "./dist/index.d.ts",
+                "default": "./dist/index.js"
+            }
         }
     },
+    "types": "dist/index.d.ts",
     "keywords": [
         "apify",
         "sqlite",


### PR DESCRIPTION
Resolves https://github.com/apify/apify-storage-local-js/issues/62.

I found that this package was causing type errors in my application. The proposed solution is the least intrusive I have found. I considered overhauling the bundling pipeline altogether using something like Rollup. While it seems to be a better way of achieving ESM+CJS compatibility, it could present breaking changes and have all kinds of side effects, so I opted for patching package.json instead.

References:
https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/FalseCJS.md (In-Depth about "Masquerading as CJS" problem)
https://github.com/microsoft/TypeScript/issues/52363#issuecomment-1659179354 (TL;DR solution)
