### PR TITLE
chore: add oxfmt and apply formatting

### DIFF
--- a/.github/scripts/before-beta-release.js
+++ b/.github/scripts/before-beta-release.js
@@ -16,17 +16,19 @@ pkgJson.version = nextVersion;
 fs.writeFileSync(PKG_JSON_PATH, JSON.stringify(pkgJson, null, 2) + '\n');
 
 function getNextVersion(version) {
-    const versionString = execSync(`npm show ${PACKAGE_NAME} versions --json`, { encoding: 'utf8'});
+    const versionString = execSync(`npm show ${PACKAGE_NAME} versions --json`, { encoding: 'utf8' });
     const versions = JSON.parse(versionString);
 
-    if (versions.some(v => v === VERSION)) {
-        console.error(`before-deploy: A release with version ${VERSION} already exists. Please increment version accordingly.`);
+    if (versions.some((v) => v === VERSION)) {
+        console.error(
+            `before-deploy: A release with version ${VERSION} already exists. Please increment version accordingly.`,
+        );
         process.exit(1);
     }
 
     const prereleaseNumbers = versions
-        .filter(v => (v.startsWith(VERSION) && v.includes('-')))
-        .map(v => Number(v.match(/\.(\d+)$/)[1]));
+        .filter((v) => v.startsWith(VERSION) && v.includes('-'))
+        .map((v) => Number(v.match(/\.(\d+)$/)[1]));
     const lastPrereleaseNumber = Math.max(-1, ...prereleaseNumbers);
-    return `${version}-beta.${lastPrereleaseNumber + 1}`
+    return `${version}-beta.${lastPrereleaseNumber + 1}`;
 }

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -56,3 +56,17 @@ jobs:
             -   name: Install pnpm and dependencies
                 uses: apify/workflows/pnpm-install@main
             -   run: pnpm lint
+
+    format-check:
+        name: Format check
+        runs-on: ubuntu-latest
+
+        steps:
+            -   uses: actions/checkout@v5
+            -   name: Use Node.js 24
+                uses: actions/setup-node@v6
+                with:
+                    node-version: 24
+            -   name: Install pnpm and dependencies
+                uses: apify/workflows/pnpm-install@main
+            -   run: pnpm format:check

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,16 @@
+{
+    "tabWidth": 4,
+    "singleQuote": true,
+    "trailingComma": "all",
+    "printWidth": 120,
+    "ignorePatterns": [
+        "**/*.md",
+        "**/*.json",
+        "**/*.jsonc",
+        "**/*.yaml",
+        "**/*.yml",
+        "**/node_modules",
+        "dist",
+        "coverage"
+    ]
+}

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -12,11 +12,7 @@ export default async (): Promise<Config.InitialOptions> => ({
     testRunner: 'jest-circus/runner',
     testTimeout: 5000,
     // collectCoverage: true,
-    collectCoverageFrom: [
-        '**/src/**/*.ts',
-        '**/src/**/*.js',
-        '!**/node_modules/**',
-    ],
+    collectCoverageFrom: ['**/src/**/*.ts', '**/src/**/*.js', '!**/node_modules/**'],
     maxWorkers: 3,
     globalSetup: join(__dirname, 'test', '_globalSetup.ts'),
     globalTeardown: join(__dirname, 'test', '_globalTeardown.ts'),

--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
         "test": "jest",
         "lint": "oxlint --type-aware",
         "lint:fix": "oxlint --type-aware --fix",
+        "format": "oxfmt",
+        "format:check": "oxfmt --check",
         "build:watch": "tsc -b src -w"
     },
     "dependencies": {
@@ -77,6 +79,7 @@
         "@types/node": "^20.2.5",
         "gen-esm-wrapper": "^1.1.3",
         "jest": "^29.5.0",
+        "oxfmt": "0.46.0",
         "oxlint": "1.62.0",
         "oxlint-tsgolint": "0.22.0",
         "ts-jest": "^29.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       jest:
         specifier: ^29.5.0
         version: 29.7.0(@types/node@20.19.39)(ts-node@10.9.2(@types/node@20.19.39)(typescript@5.1.3))
+      oxfmt:
+        specifier: 0.46.0
+        version: 0.46.0
       oxlint:
         specifier: 1.62.0
         version: 1.62.0(oxlint-tsgolint@0.22.0)
@@ -356,6 +359,128 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
+  '@oxfmt/binding-android-arm-eabi@0.46.0':
+    resolution: {integrity: sha512-b1doV4WRcJU+BESSlCvCjV+5CEr/T6h0frArAdV26Nir+gGNFNaylvDiiMPfF1pxeV0txZEs38ojzJaxBYg+ng==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxfmt/binding-android-arm64@0.46.0':
+    resolution: {integrity: sha512-v6+HhjsoV3GO0u2u9jLSAZrvWfTraDxKofUIQ7/ktS7tzS+epVsxdHmeM+XxuNcAY/nWxxU1Sg4JcGTNRXraBA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxfmt/binding-darwin-arm64@0.46.0':
+    resolution: {integrity: sha512-3eeooJGrqGIlI5MyryDZsAcKXSmKIgAD4yYtfRrRJzXZ0UTFZtiSveIur56YPrGMYZwT4XyVhHsMqrNwr1XeFA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxfmt/binding-darwin-x64@0.46.0':
+    resolution: {integrity: sha512-QG8BDM0CXWbu84k2SKmCqfEddPQPFiBicwtYnLqHRWZZl57HbtOLRMac/KTq2NO4AEc4ICCBpFxJIV9zcqYfkQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxfmt/binding-freebsd-x64@0.46.0':
+    resolution: {integrity: sha512-9DdCqS/n2ncu/Chazvt3cpgAjAmIGQDz7hFKSrNItMApyV/Ja9mz3hD4JakIE3nS8PW9smEbPWnb389QLBY4nw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.46.0':
+    resolution: {integrity: sha512-Dgs7VeE2jT0LHMhw6tPEt0xQYe54kBqHEovmWsv4FVQlegCOvlIJNx0S8n4vj8WUtpT+Z6BD2HhKJPLglLxvZg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.46.0':
+    resolution: {integrity: sha512-Zxn3adhTH13JKnU4xXJj8FeEfF680XjXh3gSShKl57HCMBRde2tUJTgogV/1MSHA80PJEVrDa7r66TLVq3Ia7Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm64-gnu@0.46.0':
+    resolution: {integrity: sha512-+TWipjrgVM8D7aIdDD0tlr3teLTTvQTn7QTE5BpT10H1Fj82gfdn9X6nn2sDgx/MepuSCfSnzFNJq2paLL0OiA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-arm64-musl@0.46.0':
+    resolution: {integrity: sha512-aAUPBWJ1lGwwnxZUEDLJ94+Iy6MuwJwPxUgO4sCA5mEEyDk7b+cDQ+JpX1VR150Zoyd+D49gsrUzpUK5h587Eg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.46.0':
+    resolution: {integrity: sha512-ufBCJukyFX/UDrokP/r6BGDoTInnsDs7bxyzKAgMiZlt2Qu8GPJSJ6Zm6whIiJzKk0naxA8ilwmbO1LMw6Htxw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.46.0':
+    resolution: {integrity: sha512-eqtlC2YmPqjun76R1gVfGLuKWx7NuEnLEAudZ7n6ipSKbCZTqIKSs1b5Y8K/JHZsRpLkeSmAAjig5HOIg8fQzQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-riscv64-musl@0.46.0':
+    resolution: {integrity: sha512-yccVOO2nMXkQLGgy0He3EQEwKD7NF0zEk+/OWmroznkqXyJdN6bfK0LtNnr6/14Bh3FjpYq7bP33l/VloCnxpA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-linux-s390x-gnu@0.46.0':
+    resolution: {integrity: sha512-aAf7fG23OQCey6VRPj9IeCraoYtpgtx0ZyJ1CXkPyT1wjzBE7c3xtuxHe/AdHaJfVVb/SXpSk8Gl1LzyQupSqw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-x64-gnu@0.46.0':
+    resolution: {integrity: sha512-q0JPsTMyJNjYrBvYFDz4WbVsafNZaPCZv4RnFypRotLqpKROtBZcEaXQW4eb9YmvLU3NckVemLJnzkSZSdmOxw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-x64-musl@0.46.0':
+    resolution: {integrity: sha512-7LsLY9Cw57GPkhSR+duI3mt9baRczK/DtHYSldQ4BEU92da9igBQNl4z7Vq5U9NNPsh1FmpKvv1q9WDtiUQR1A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-openharmony-arm64@0.46.0':
+    resolution: {integrity: sha512-lHiBOz8Duaku7JtRNLlps3j++eOaICPZSd8FCVmTDM4DFOPT71Bjn7g6iar1z7StXlKRweUKxWUs4sA+zWGDXg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxfmt/binding-win32-arm64-msvc@0.46.0':
+    resolution: {integrity: sha512-/5ktYUliP89RhgC37DBH1x20U5zPSZMy3cMEcO0j3793rbHP9MWsknBwQB6eozRzWmYrh0IFM/p20EbPvDlYlg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxfmt/binding-win32-ia32-msvc@0.46.0':
+    resolution: {integrity: sha512-3WTnoiuIr8XvV0DIY7SN+1uJSwKf4sPpcbHfobcRT9JutGcLaef/miyBB87jxd3aqH+mS0+G5lsgHuXLUwjjpQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxfmt/binding-win32-x64-msvc@0.46.0':
+    resolution: {integrity: sha512-IXxiQpkYnOwNfP23vzwSfhdpxJzyiPTY7eTn6dn3DsriKddESzM8i6kfq9R7CD/PUJwCvQT22NgtygBeug3KoA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
 
   '@oxlint-tsgolint/darwin-arm64@0.22.0':
     resolution: {integrity: sha512-/exgXceakHbQrzaHTtKOe7MuDATaWMCCWpsCDQCZKeYhLGXzComipTrCYnHzAXrdnNBb5r5K+RRf5A6ormrhMA==}
@@ -1365,6 +1490,11 @@ packages:
     resolution: {integrity: sha512-dD4UpyBh/9m4X2NVjA+73/ZPBRF+uF4zIMFvvQsabMiEK8x41L3rQ8EENOi35kyyoaJwNxEeJcP6Fj1H4U409Q==}
     engines: {node: '>=12'}
 
+  oxfmt@0.46.0:
+    resolution: {integrity: sha512-CopwJOwPAjZ9p76fCvz+mSOJTw9/NY3cSksZK3VO/bUQ8UoEcketNgUuYS0UB3p+R9XnXe7wGGXUmyFxc7QxJA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   oxlint-tsgolint@0.22.0:
     resolution: {integrity: sha512-ku4MecLmCQIj1ScCtzNAqTuyl0BJQ02B36fJT+c5XQihHpYSFak+FC3GYO5fPyYk4oDwi0w0S7hTvrpNzuZhig==}
     hasBin: true
@@ -1588,6 +1718,10 @@ packages:
   test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
+
+  tinypool@2.1.0:
+    resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
+    engines: {node: ^20.0.0 || >=22.0.0}
 
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
@@ -2141,6 +2275,63 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@oxfmt/binding-android-arm-eabi@0.46.0':
+    optional: true
+
+  '@oxfmt/binding-android-arm64@0.46.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-arm64@0.46.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-x64@0.46.0':
+    optional: true
+
+  '@oxfmt/binding-freebsd-x64@0.46.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.46.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.46.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-gnu@0.46.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-musl@0.46.0':
+    optional: true
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.46.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.46.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-musl@0.46.0':
+    optional: true
+
+  '@oxfmt/binding-linux-s390x-gnu@0.46.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-gnu@0.46.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-musl@0.46.0':
+    optional: true
+
+  '@oxfmt/binding-openharmony-arm64@0.46.0':
+    optional: true
+
+  '@oxfmt/binding-win32-arm64-msvc@0.46.0':
+    optional: true
+
+  '@oxfmt/binding-win32-ia32-msvc@0.46.0':
+    optional: true
+
+  '@oxfmt/binding-win32-x64-msvc@0.46.0':
+    optional: true
 
   '@oxlint-tsgolint/darwin-arm64@0.22.0':
     optional: true
@@ -3248,6 +3439,30 @@ snapshots:
       lodash.isequal: 4.5.0
       vali-date: 1.0.0
 
+  oxfmt@0.46.0:
+    dependencies:
+      tinypool: 2.1.0
+    optionalDependencies:
+      '@oxfmt/binding-android-arm-eabi': 0.46.0
+      '@oxfmt/binding-android-arm64': 0.46.0
+      '@oxfmt/binding-darwin-arm64': 0.46.0
+      '@oxfmt/binding-darwin-x64': 0.46.0
+      '@oxfmt/binding-freebsd-x64': 0.46.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.46.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.46.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.46.0
+      '@oxfmt/binding-linux-arm64-musl': 0.46.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.46.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.46.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.46.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.46.0
+      '@oxfmt/binding-linux-x64-gnu': 0.46.0
+      '@oxfmt/binding-linux-x64-musl': 0.46.0
+      '@oxfmt/binding-openharmony-arm64': 0.46.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.46.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.46.0
+      '@oxfmt/binding-win32-x64-msvc': 0.46.0
+
   oxlint-tsgolint@0.22.0:
     optionalDependencies:
       '@oxlint-tsgolint/darwin-arm64': 0.22.0
@@ -3489,6 +3704,8 @@ snapshots:
       '@istanbuljs/schema': 0.1.6
       glob: 7.2.3
       minimatch: 3.1.5
+
+  tinypool@2.1.0: {}
 
   tmpl@1.0.5: {}
 

--- a/src/body_parser.ts
+++ b/src/body_parser.ts
@@ -5,11 +5,7 @@ import contentTypeParser from 'content-type';
 import JSON5 from 'json5';
 
 const CONTENT_TYPE_JSON = 'application/json';
-const STRINGIFIABLE_CONTENT_TYPE_RXS = [
-    new RegExp(`^${CONTENT_TYPE_JSON}$`, 'i'),
-    /^application\/.*xml$/i,
-    /^text\//i,
-];
+const STRINGIFIABLE_CONTENT_TYPE_RXS = [new RegExp(`^${CONTENT_TYPE_JSON}$`, 'i'), /^application\/.*xml$/i, /^text\//i];
 
 /**
  * Parses a Buffer or ArrayBuffer using the provided content type header.
@@ -21,7 +17,10 @@ const STRINGIFIABLE_CONTENT_TYPE_RXS = [
  * If the header includes a charset, the body will be stringified only
  * if the charset represents a known encoding to Node.js or Browser.
  */
-export function maybeParseBody(body: Buffer | ArrayBuffer, contentTypeHeader: string): string | Buffer | ArrayBuffer | Record<string, unknown> {
+export function maybeParseBody(
+    body: Buffer | ArrayBuffer,
+    contentTypeHeader: string,
+): string | Buffer | ArrayBuffer | Record<string, unknown> {
     let contentType: string;
     let charset: BufferEncoding;
     try {
@@ -38,10 +37,8 @@ export function maybeParseBody(body: Buffer | ArrayBuffer, contentTypeHeader: st
     if (!areDataStringifiable(contentType, charset)) return body;
     const dataString = isomorphicBufferToString(body, charset);
 
-    return contentType === CONTENT_TYPE_JSON
-        ? JSON5.parse(dataString)
-        : dataString;
-};
+    return contentType === CONTENT_TYPE_JSON ? JSON5.parse(dataString) : dataString;
+}
 
 function isomorphicBufferToString(buffer: Buffer | ArrayBuffer, encoding: BufferEncoding): string {
     if (buffer.constructor.name !== ArrayBuffer.name) {

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -15,7 +15,7 @@ export const enum STORAGE_TYPES {
     REQUEST_QUEUE = 'Request queue',
     KEY_VALUE_STORE = 'Key-value store',
     DATASET = 'Dataset',
-};
+}
 
 /**
  * Names of all emulated storages.
@@ -24,7 +24,7 @@ export const enum STORAGE_NAMES {
     REQUEST_QUEUES = 'request_queues',
     KEY_VALUE_STORES = 'key_value_stores',
     DATASETS = 'datasets',
-};
+}
 
 /**
  * Name of the request queue master database file.

--- a/src/database_connection_cache.ts
+++ b/src/database_connection_cache.ts
@@ -61,7 +61,9 @@ export class DatabaseConnectionCache {
 
     setWalMode(enableWalMode: boolean): void {
         if (this.connections.size) {
-            throw new Error(`Cannot ${enableWalMode ? 'enable' : 'disable'} WAL mode while there are open database connections`);
+            throw new Error(
+                `Cannot ${enableWalMode ? 'enable' : 'disable'} WAL mode while there are open database connections`,
+            );
         }
         this.enableWalMode = enableWalMode;
     }

--- a/src/emulators/batch_add_requests/processed_request.ts
+++ b/src/emulators/batch_add_requests/processed_request.ts
@@ -1,7 +1,11 @@
 import { QueueOperationInfo } from '../queue_operation_info';
 
 export class ProcessedRequest extends QueueOperationInfo {
-    constructor(requestId: string, public uniqueKey: string, requestOrderNo?: number | null) {
+    constructor(
+        requestId: string,
+        public uniqueKey: string,
+        requestOrderNo?: number | null,
+    ) {
         super(requestId, requestOrderNo);
     }
 }

--- a/src/emulators/batch_add_requests/unprocessed_request.ts
+++ b/src/emulators/batch_add_requests/unprocessed_request.ts
@@ -1,5 +1,9 @@
 import type { AllowedHttpMethods } from '../../resource_clients/request_queue';
 
 export class UnprocessedRequest {
-    constructor(public uniqueKey: string, public url: string, public method?: AllowedHttpMethods) {}
+    constructor(
+        public uniqueKey: string,
+        public url: string,
+        public method?: AllowedHttpMethods,
+    ) {}
 }

--- a/src/emulators/queue_operation_info.ts
+++ b/src/emulators/queue_operation_info.ts
@@ -2,7 +2,10 @@ export class QueueOperationInfo {
     wasAlreadyPresent: boolean;
     wasAlreadyHandled: boolean;
 
-    constructor(public requestId: string, requestOrderNo?: number | null) {
+    constructor(
+        public requestId: string,
+        requestOrderNo?: number | null,
+    ) {
         this.wasAlreadyPresent = requestOrderNo !== undefined;
         this.wasAlreadyHandled = requestOrderNo === null;
     }

--- a/src/emulators/request_queue_emulator.ts
+++ b/src/emulators/request_queue_emulator.ts
@@ -12,7 +12,7 @@ const ERROR_QUEUE_DOES_NOT_EXIST = 'SQLITE_CONSTRAINT_FOREIGNKEY';
 
 export interface RequestQueueEmulatorOptions {
     queueDir: string;
-    dbConnections: DatabaseConnectionCache
+    dbConnections: DatabaseConnectionCache;
 }
 
 interface ErrorWithCode extends Error {
@@ -64,14 +64,14 @@ interface RequestQueueStatements {
     adjustTotalAndHandledRequestCounts: Statement<[{ id: string; totalAdjustment: number; handledAdjustment: number }]>;
     selectRequestOrderNoByModel: Statement<[requestModel: RequestModel]>;
     selectRequestJsonByModel: Statement<[{ requestId: string; queueId: string }]>;
-    selectRequestJsonsByQueueIdWithLimit: Statement<[{ queueId: string, limit: number }]>;
+    selectRequestJsonsByQueueIdWithLimit: Statement<[{ queueId: string; limit: number }]>;
     insertRequestByModel: Statement<[requestModel: RequestModel]>;
     updateRequestByModel: Statement<[requestModel: RequestModel]>;
     deleteRequestById: Statement<[id: string]>;
     fetchRequestNotExpired: Statement<[id: string]>;
     fetchRequestNotExpiredAndLocked: Statement<{ id: string; currentTime: number }>;
     updateOrderNo: Statement<{ id: string; orderNo: number }>;
-    fetchRequestHeadThatWillBeLocked: Statement<{ queueId: string; limit: number; currentTime: number; }>;
+    fetchRequestHeadThatWillBeLocked: Statement<{ queueId: string; limit: number; currentTime: number }>;
 }
 
 interface RequestQueueTransactions {
@@ -107,7 +107,9 @@ export class RequestQueueEmulator {
             this.db = dbConnections.openConnection(this.dbPath);
         } catch (err) {
             if (err.code !== 'ENOENT') throw err;
-            const newError = new Error(`Request queue with id: ${parse(queueDir).name} does not exist.`) as ErrorWithCode;
+            const newError = new Error(
+                `Request queue with id: ${parse(queueDir).name} does not exist.`,
+            ) as ErrorWithCode;
             newError.code = 'ENOENT';
             throw newError;
         }
@@ -224,12 +226,13 @@ export class RequestQueueEmulator {
         return this.transactions.listAndLockHead(queueId, limit, lockSecs);
     }
 
-    private updateOrderNo({ id, orderNo }: { id: string; orderNo: number; }) {
+    private updateOrderNo({ id, orderNo }: { id: string; orderNo: number }) {
         this.statements.updateOrderNo.run({ id, orderNo });
     }
 
     private _createTables() {
-        this.db.prepare(`
+        this.db
+            .prepare(`
             CREATE TABLE IF NOT EXISTS ${this.queueTableName}(
                 id INTEGER PRIMARY KEY,
                 name TEXT UNIQUE,
@@ -240,8 +243,10 @@ export class RequestQueueEmulator {
                 handledRequestCount INTEGER DEFAULT 0,
                 pendingRequestCount INTEGER GENERATED ALWAYS AS (totalRequestCount - handledRequestCount) VIRTUAL
             )
-        `).run();
-        this.db.prepare(`
+        `)
+            .run();
+        this.db
+            .prepare(`
             CREATE TABLE IF NOT EXISTS ${this.requestsTableName}(
                 queueId INTEGER NOT NULL REFERENCES ${this.queueTableName}(id) ON DELETE CASCADE,
                 id TEXT NOT NULL,
@@ -253,7 +258,8 @@ export class RequestQueueEmulator {
                 json TEXT NOT NULL,
                 PRIMARY KEY (queueId, id, uniqueKey)
             )
-        `).run();
+        `)
+            .run();
     }
 
     private _createTriggers() {
@@ -275,80 +281,90 @@ export class RequestQueueEmulator {
     }
 
     private _createIndexes() {
-        this.db.prepare(`
+        this.db
+            .prepare(`
             CREATE INDEX IF NOT EXISTS I_queueId_orderNo
             ON ${this.requestsTableName}(queueId, orderNo)
             WHERE orderNo IS NOT NULL
-        `).run();
+        `)
+            .run();
     }
 
     private _createStatements() {
         this.statements = {
-            selectById: this.db.prepare(/* sql */`
+            selectById: this.db.prepare(/* sql */ `
                 SELECT *, CAST(id as TEXT) as id
                 FROM ${this.queueTableName}
                 WHERE id = ?
             `),
-            deleteById: this.db.prepare(/* sql */`
+            deleteById: this.db.prepare(/* sql */ `
                 DELETE FROM ${this.queueTableName}
                 WHERE id = CAST(? as INTEGER)
             `),
-            selectByName: this.db.prepare(/* sql */`
+            selectByName: this.db.prepare(/* sql */ `
                 SELECT *, CAST(id as TEXT) as id
                 FROM ${this.queueTableName}
                 WHERE name = ?
             `),
-            insertByName: this.db.prepare(/* sql */`
+            insertByName: this.db.prepare(/* sql */ `
                 INSERT INTO ${this.queueTableName}(name)
                 VALUES(?)
             `),
-            selectModifiedAtById: this.db.prepare(/* sql */`
+            selectModifiedAtById: this.db
+                .prepare(/* sql */ `
                 SELECT modifiedAt
                 FROM ${this.queueTableName}
                 WHERE id = ?
-            `).pluck(),
-            updateNameById: this.db.prepare(/* sql */`
+            `)
+                .pluck(),
+            updateNameById: this.db.prepare(/* sql */ `
                 UPDATE ${this.queueTableName}
                 SET name = :name
                 WHERE id = CAST(:id as INTEGER)
             `),
-            updateModifiedAtById: this.db.prepare(/* sql */`
+            updateModifiedAtById: this.db.prepare(/* sql */ `
                 UPDATE ${this.queueTableName}
                 SET modifiedAt = ${TIMESTAMP_SQL}
                 WHERE id = CAST(? as INTEGER)
             `),
-            updateAccessedAtById: this.db.prepare(/* sql */`
+            updateAccessedAtById: this.db.prepare(/* sql */ `
                 UPDATE ${this.queueTableName}
                 SET accessedAt = ${TIMESTAMP_SQL}
                 WHERE id = CAST(? as INTEGER)
             `),
-            adjustTotalAndHandledRequestCounts: this.db.prepare(/* sql */`
+            adjustTotalAndHandledRequestCounts: this.db.prepare(/* sql */ `
                 UPDATE ${this.queueTableName}
                 SET totalRequestCount = totalRequestCount + :totalAdjustment,
                     handledRequestCount = handledRequestCount + :handledAdjustment
                 WHERE id = CAST(:id as INTEGER)
             `),
-            selectRequestOrderNoByModel: this.db.prepare(/* sql */`
+            selectRequestOrderNoByModel: this.db
+                .prepare(/* sql */ `
                 SELECT orderNo FROM ${this.requestsTableName}
                 WHERE queueId = CAST(:queueId as INTEGER) AND id = :id
-            `).pluck(),
-            selectRequestJsonByModel: this.db.prepare(/* sql */`
+            `)
+                .pluck(),
+            selectRequestJsonByModel: this.db
+                .prepare(/* sql */ `
                 SELECT "json" FROM ${this.requestsTableName}
                 WHERE queueId = CAST(:queueId as INTEGER) AND id = :requestId
-            `).pluck(),
-            selectRequestJsonsByQueueIdWithLimit: this.db.prepare(/* sql */`
+            `)
+                .pluck(),
+            selectRequestJsonsByQueueIdWithLimit: this.db
+                .prepare(/* sql */ `
                 SELECT "json" FROM ${this.requestsTableName}
                 WHERE queueId = CAST(:queueId as INTEGER) AND orderNo IS NOT NULL
                 LIMIT :limit
-            `).pluck(),
-            insertRequestByModel: this.db.prepare(/* sql */`
+            `)
+                .pluck(),
+            insertRequestByModel: this.db.prepare(/* sql */ `
                 INSERT INTO ${this.requestsTableName}(
                     id, queueId, orderNo, url, uniqueKey, method, retryCount, json
                 ) VALUES (
                     :id, CAST(:queueId as INTEGER), :orderNo, :url, :uniqueKey, :method, :retryCount, :json
                 )
             `),
-            updateRequestByModel: this.db.prepare(/* sql */`
+            updateRequestByModel: this.db.prepare(/* sql */ `
                 UPDATE ${this.requestsTableName}
                 SET orderNo = :orderNo,
                     url = :url,
@@ -358,16 +374,16 @@ export class RequestQueueEmulator {
                     json = :json
                 WHERE queueId = CAST(:queueId as INTEGER) AND id = :id
             `),
-            deleteRequestById: this.db.prepare(/* sql */`
+            deleteRequestById: this.db.prepare(/* sql */ `
                 DELETE FROM ${this.requestsTableName}
                 WHERE id = ?
             `),
-            fetchRequestNotExpired: this.db.prepare(/* sql */`
+            fetchRequestNotExpired: this.db.prepare(/* sql */ `
                 SELECT id, orderNo FROM ${this.requestsTableName}
                 WHERE id = ?
                 AND orderNo IS NOT NULL
             `),
-            fetchRequestNotExpiredAndLocked: this.db.prepare(/* sql */`
+            fetchRequestNotExpiredAndLocked: this.db.prepare(/* sql */ `
                 SELECT id FROM ${this.requestsTableName}
                 WHERE id = :id
                 AND orderNo IS NOT NULL
@@ -376,7 +392,7 @@ export class RequestQueueEmulator {
                     OR orderNo < -(:currentTime)
                 )
             `),
-            fetchRequestHeadThatWillBeLocked: this.db.prepare(/* sql */`
+            fetchRequestHeadThatWillBeLocked: this.db.prepare(/* sql */ `
                 SELECT id, "json", orderNo FROM ${this.requestsTableName}
                 WHERE queueId = CAST(:queueId as INTEGER)
                 AND orderNo IS NOT NULL
@@ -385,7 +401,7 @@ export class RequestQueueEmulator {
                 ORDER BY orderNo ASC
                 LIMIT :limit
             `),
-            updateOrderNo: this.db.prepare(/* sql */`
+            updateOrderNo: this.db.prepare(/* sql */ `
                 UPDATE ${this.requestsTableName}
                 SET orderNo = :orderNo
                 WHERE id = :id
@@ -485,7 +501,9 @@ export class RequestQueueEmulator {
                 // TODO
             }),
             prolongRequestLock: this.db.transaction((id, options) => {
-                const existingRequest = this.statements.fetchRequestNotExpired.get(id) as { orderNo: number; id: string } | undefined;
+                const existingRequest = this.statements.fetchRequestNotExpired.get(id) as
+                    | { orderNo: number; id: string }
+                    | undefined;
 
                 if (!existingRequest) {
                     throw new Error(`Request with ID ${id} was already handled or doesn't exist`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,10 +70,14 @@ export class ApifyStorageLocal {
     private isDatasetDirInitialized = false;
 
     constructor(options: ApifyStorageLocalOptions = {}) {
-        ow(options, 'ApifyStorageLocalOptions', ow.optional.object.exactShape({
-            storageDir: ow.optional.string,
-            enableWalMode: ow.optional.boolean,
-        }));
+        ow(
+            options,
+            'ApifyStorageLocalOptions',
+            ow.optional.object.exactShape({
+                storageDir: ow.optional.string,
+                enableWalMode: ow.optional.boolean,
+            }),
+        );
 
         /**
          * Returns the first argument which is not `undefined`.
@@ -84,7 +88,9 @@ export class ApifyStorageLocal {
         const enableWalMode = bool(process.env.APIFY_LOCAL_STORAGE_ENABLE_WAL_MODE) ?? options.enableWalMode ?? true;
 
         if (!pathExistsSync(storageDir)) {
-            log.info(`Created a data storage folder at ${storageDir}. You can override the path by setting the APIFY_LOCAL_STORAGE_DIR environment variable`);
+            log.info(
+                `Created a data storage folder at ${storageDir}. You can override the path by setting the APIFY_LOCAL_STORAGE_DIR environment variable`,
+            );
             ensureDirSync(storageDir);
         }
 
@@ -145,10 +151,13 @@ export class ApifyStorageLocal {
     requestQueue(id: string, options: RequestQueueOptions = {}): RequestQueueClient {
         ow(id, ow.string);
         // Matching the Client validation.
-        ow(options, ow.object.exactShape({
-            clientKey: ow.optional.string,
-            timeoutSecs: ow.optional.number,
-        }));
+        ow(
+            options,
+            ow.object.exactShape({
+                clientKey: ow.optional.string,
+                timeoutSecs: ow.optional.number,
+            }),
+        );
         this._ensureRequestQueueDir();
         return new RequestQueueClient({
             name: id,
@@ -167,10 +176,16 @@ export class ApifyStorageLocal {
         const defaultDatasetPath = resolve(this.datasetDir, LOCAL_ENV_VARS[ENV_VARS.DEFAULT_DATASET_ID]);
         await this.removeFiles(defaultDatasetPath);
 
-        const defaultKeyValueStorePath = resolve(this.keyValueStoreDir, LOCAL_ENV_VARS[ENV_VARS.DEFAULT_KEY_VALUE_STORE_ID]);
+        const defaultKeyValueStorePath = resolve(
+            this.keyValueStoreDir,
+            LOCAL_ENV_VARS[ENV_VARS.DEFAULT_KEY_VALUE_STORE_ID],
+        );
         await this.removeFiles(defaultKeyValueStorePath);
 
-        const defaultRequestQueuePath = resolve(this.requestQueueDir, LOCAL_ENV_VARS[ENV_VARS.DEFAULT_REQUEST_QUEUE_ID]);
+        const defaultRequestQueuePath = resolve(
+            this.requestQueueDir,
+            LOCAL_ENV_VARS[ENV_VARS.DEFAULT_REQUEST_QUEUE_ID],
+        );
         await this.removeFiles(defaultRequestQueuePath);
     }
 
@@ -226,7 +241,7 @@ export class ApifyStorageLocal {
 
             const innerStorageDir = resolve(storageDir, dirent.name);
 
-            let innerDirents = readdirSync(innerStorageDir).filter((fileName) => !(/(^|\/)\.[^/.]/g).test(fileName));
+            let innerDirents = readdirSync(innerStorageDir).filter((fileName) => !/(^|\/)\.[^/.]/g.test(fileName));
 
             if (storageType === STORAGE_TYPES.KEY_VALUE_STORE) {
                 innerDirents = innerDirents.filter((fileName) => !RegExp(KEY_VALUE_STORE_KEYS.INPUT).test(fileName));
@@ -239,10 +254,12 @@ export class ApifyStorageLocal {
 
         const dirsNo = dirsWithPreviousState.length;
         if (dirsNo) {
-            log.warning(`The following ${storageType} director${dirsNo === 1 ? 'y' : 'ies'} contain${dirsNo === 1 ? 's' : ''} a previous state:`
-                + `\n      ${dirsWithPreviousState.join('\n      ')}`
-                + '\n      If you did not intend to persist the state - '
-                + `please clear the respective director${dirsNo === 1 ? 'y' : 'ies'} and re-start the actor.`);
+            log.warning(
+                `The following ${storageType} director${dirsNo === 1 ? 'y' : 'ies'} contain${dirsNo === 1 ? 's' : ''} a previous state:` +
+                    `\n      ${dirsWithPreviousState.join('\n      ')}` +
+                    '\n      If you did not intend to persist the state - ' +
+                    `please clear the respective director${dirsNo === 1 ? 'y' : 'ies'} and re-start the actor.`,
+            );
         }
     }
 }

--- a/src/resource_clients/dataset.ts
+++ b/src/resource_clients/dataset.ts
@@ -52,7 +52,7 @@ export class DatasetClient {
 
     itemCount?: number = undefined;
 
-    constructor({ name, storageDir } : DatasetClientOptions) {
+    constructor({ name, storageDir }: DatasetClientOptions) {
         this.name = name;
         this.storeDir = join(storageDir, name);
     }
@@ -81,9 +81,12 @@ export class DatasetClient {
     async update(newFields: DatasetClientUpdateOptions): Promise<Record<string, unknown>> {
         // The validation is intentionally loose to prevent issues
         // when swapping to a remote storage in production.
-        ow(newFields, ow.object.partialShape({
-            name: ow.optional.string.minLength(1),
-        }));
+        ow(
+            newFields,
+            ow.object.partialShape({
+                name: ow.optional.string.minLength(1),
+            }),
+        );
         if (!newFields.name) return {};
 
         const newPath = join(dirname(this.storeDir), newFields.name);
@@ -116,26 +119,28 @@ export class DatasetClient {
     async listItems(options: DatasetClientListOptions = {}): Promise<PaginationList> {
         this._ensureItemCount();
         // The extra code is to enable a custom validation message.
-        ow(options, ow.object.validate((value) => ({
-            validator: ow.isValid(value, ow.object.exactShape({
-                // clean: ow.optional.boolean,
-                desc: ow.optional.boolean,
-                // fields: ow.optional.array.ofType(ow.string),
-                // omit: ow.optional.array.ofType(ow.string),
-                limit: ow.optional.number,
-                offset: ow.optional.number,
-                // skipEmpty: ow.optional.boolean,
-                // skipHidden: ow.optional.boolean,
-                // unwind: ow.optional.string,
+        ow(
+            options,
+            ow.object.validate((value) => ({
+                validator: ow.isValid(
+                    value,
+                    ow.object.exactShape({
+                        // clean: ow.optional.boolean,
+                        desc: ow.optional.boolean,
+                        // fields: ow.optional.array.ofType(ow.string),
+                        // omit: ow.optional.array.ofType(ow.string),
+                        limit: ow.optional.number,
+                        offset: ow.optional.number,
+                        // skipEmpty: ow.optional.boolean,
+                        // skipHidden: ow.optional.boolean,
+                        // unwind: ow.optional.string,
+                    }),
+                ),
+                message: 'Local dataset emulation supports only the "desc", "limit" and "offset" options.',
             })),
-            message: 'Local dataset emulation supports only the "desc", "limit" and "offset" options.',
-        })));
+        );
 
-        const {
-            limit = LIST_ITEMS_LIMIT,
-            offset = 0,
-            desc,
-        } = options;
+        const { limit = LIST_ITEMS_LIMIT, offset = 0, desc } = options;
 
         const [start, end] = this._getStartAndEndIndexes(
             desc ? Math.max(this.itemCount! - offset - limit, 0) : offset,
@@ -160,11 +165,7 @@ export class DatasetClient {
 
     async pushItems(items: DataTypes): Promise<void> {
         this._ensureItemCount();
-        ow(items, ow.any(
-            ow.object,
-            ow.string,
-            ow.array.ofType(ow.any(ow.object, ow.string)),
-        ));
+        ow(items, ow.any(ow.object, ow.string, ow.array.ofType(ow.any(ow.object, ow.string))));
 
         items = this._normalizeItems(items);
         const promises = items.map(async (item) => {
@@ -195,9 +196,7 @@ export class DatasetClient {
             items = JSON.parse(items);
         }
 
-        return Array.isArray(items)
-            ? items.map(this._normalizeItem)
-            : [this._normalizeItem(items)];
+        return Array.isArray(items) ? items.map(this._normalizeItem) : [this._normalizeItem(items)];
     }
 
     private _normalizeItem(item: string | Record<string, unknown>) {
@@ -206,7 +205,9 @@ export class DatasetClient {
         }
 
         if (Array.isArray(item)) {
-            throw new Error(`Each dataset item can only be a single JSON object, not an array. Received: [${item.join(',\n')}]`);
+            throw new Error(
+                `Each dataset item can only be a single JSON object, not an array. Received: [${item.join(',\n')}]`,
+            );
         }
 
         return item;
@@ -261,7 +262,7 @@ export class DatasetClient {
         throw err;
     }
 
-    private _updateTimestamps({ mtime }: { mtime?: boolean; } = {}) {
+    private _updateTimestamps({ mtime }: { mtime?: boolean } = {}) {
         // It's throwing EINVAL on Windows. Not sure why,
         // so the function is a best effort only.
         const now = new Date();
@@ -269,9 +270,10 @@ export class DatasetClient {
         if (mtime) {
             promise = utimes(this.storeDir, now, now);
         } else {
-            promise = stat(this.storeDir)
-                .then(async (stats) => utimes(this.storeDir, now, stats.mtime));
+            promise = stat(this.storeDir).then(async (stats) => utimes(this.storeDir, now, stats.mtime));
         }
-        promise.catch(() => { /* we don't care that much if it sometimes fails */ });
+        promise.catch(() => {
+            /* we don't care that much if it sometimes fails */
+        });
     }
 }

--- a/src/resource_clients/key_value_store.ts
+++ b/src/resource_clients/key_value_store.ts
@@ -1,4 +1,15 @@
-import { stat, move, remove, readdir, createReadStream, readFile, utimes, createWriteStream, writeFile, unlink } from 'fs-extra';
+import {
+    stat,
+    move,
+    remove,
+    readdir,
+    createReadStream,
+    readFile,
+    utimes,
+    createWriteStream,
+    writeFile,
+    unlink,
+} from 'fs-extra';
 import mime from 'mime-types';
 import ow from 'ow';
 import { join, dirname, parse, resolve } from 'node:path';
@@ -9,7 +20,21 @@ import { maybeParseBody } from '../body_parser';
 import { DEFAULT_API_PARAM_LIMIT } from '../consts';
 
 const DEFAULT_LOCAL_FILE_EXTENSION = 'bin';
-const COMMON_LOCAL_FILE_EXTENSIONS = ['json', 'jpeg', 'png', 'html', 'jpg', 'bin', 'txt', 'xml', 'pdf', 'mp3', 'js', 'css', 'csv'];
+const COMMON_LOCAL_FILE_EXTENSIONS = [
+    'json',
+    'jpeg',
+    'png',
+    'html',
+    'jpg',
+    'bin',
+    'txt',
+    'xml',
+    'pdf',
+    'mp3',
+    'js',
+    'css',
+    'csv',
+];
 
 const streamFinished = util.promisify(stream.finished);
 
@@ -95,9 +120,12 @@ export class KeyValueStoreClient {
     async update(newFields: KeyValueStoreClientUpdateOptions): Promise<Record<string, unknown>> {
         // The validation is intentionally loose to prevent issues
         // when swapping to a remote storage in production.
-        ow(newFields, ow.object.partialShape({
-            name: ow.optional.string.minLength(1),
-        }));
+        ow(
+            newFields,
+            ow.object.partialShape({
+                name: ow.optional.string.minLength(1),
+            }),
+        );
 
         if (!newFields.name) return {};
 
@@ -123,15 +151,15 @@ export class KeyValueStoreClient {
     }
 
     async listKeys(options: KeyValueStoreClientListOptions = {}): Promise<KeyValueStoreClientListData> {
-        ow(options, ow.object.exactShape({
-            limit: ow.optional.number.greaterThan(0),
-            exclusiveStartKey: ow.optional.string,
-        }));
+        ow(
+            options,
+            ow.object.exactShape({
+                limit: ow.optional.number.greaterThan(0),
+                exclusiveStartKey: ow.optional.string,
+            }),
+        );
 
-        const {
-            limit = DEFAULT_API_PARAM_LIMIT,
-            exclusiveStartKey,
-        } = options;
+        const { limit = DEFAULT_API_PARAM_LIMIT, exclusiveStartKey } = options;
 
         let files!: string[];
         try {
@@ -175,9 +203,7 @@ export class KeyValueStoreClient {
         const lastItemInStore = items[items.length - 1];
         const lastSelectedItem = limitedItems[limitedItems.length - 1];
         const isLastSelectedItemAbsolutelyLast = lastItemInStore === lastSelectedItem;
-        const nextExclusiveStartKey = isLastSelectedItemAbsolutelyLast
-            ? undefined
-            : lastSelectedItem.key;
+        const nextExclusiveStartKey = isLastSelectedItemAbsolutelyLast ? undefined : lastSelectedItem.key;
 
         this._updateTimestamps();
         return {
@@ -206,15 +232,21 @@ export class KeyValueStoreClient {
         }
     }
 
-    async getRecord(key: string, options: KeyValueStoreClientGetRecordOptions = {}): Promise<KeyValueStoreRecord | undefined> {
+    async getRecord(
+        key: string,
+        options: KeyValueStoreClientGetRecordOptions = {},
+    ): Promise<KeyValueStoreRecord | undefined> {
         ow(key, ow.string);
-        ow(options, ow.object.exactShape({
-            buffer: ow.optional.boolean,
-            stream: ow.optional.boolean,
-            // This option is ignored, but kept here
-            // for validation consistency with API client.
-            disableRedirect: ow.optional.boolean,
-        }));
+        ow(
+            options,
+            ow.object.exactShape({
+                buffer: ow.optional.boolean,
+                stream: ow.optional.boolean,
+                // This option is ignored, but kept here
+                // for validation consistency with API client.
+                disableRedirect: ow.optional.boolean,
+            }),
+        );
 
         const handler = options.stream ? createReadStream : readFile;
 
@@ -247,11 +279,14 @@ export class KeyValueStoreClient {
     }
 
     async setRecord(record: KeyValueStoreRecord): Promise<void> {
-        ow(record, ow.object.exactShape({
-            key: ow.string,
-            value: ow.any(ow.null, ow.string, ow.number, ow.object),
-            contentType: ow.optional.string.nonEmpty,
-        }));
+        ow(
+            record,
+            ow.object.exactShape({
+                key: ow.string,
+                value: ow.any(ow.null, ow.string, ow.number, ow.object),
+                contentType: ow.optional.string.nonEmpty,
+            }),
+        );
 
         const { key } = record;
         let { value, contentType } = record;
@@ -370,7 +405,7 @@ export class KeyValueStoreClient {
         throw err;
     }
 
-    private _updateTimestamps({ mtime }: { mtime?: boolean; } = {}) {
+    private _updateTimestamps({ mtime }: { mtime?: boolean } = {}) {
         // It's throwing EINVAL on Windows. Not sure why,
         // so the function is a best effort only.
         const now = new Date();
@@ -378,9 +413,10 @@ export class KeyValueStoreClient {
         if (mtime) {
             promise = utimes(this.storeDir, now, now);
         } else {
-            promise = stat(this.storeDir)
-                .then(async (stats) => utimes(this.storeDir, now, stats.mtime));
+            promise = stat(this.storeDir).then(async (stats) => utimes(this.storeDir, now, stats.mtime));
         }
-        promise.catch(() => { /* we don't care that much if it sometimes fails */ });
+        promise.catch(() => {
+            /* we don't care that much if it sometimes fails */
+        });
     }
 }

--- a/src/resource_clients/request_queue.ts
+++ b/src/resource_clients/request_queue.ts
@@ -2,7 +2,7 @@ import { join, dirname } from 'node:path';
 import ow from 'ow';
 import { move, remove } from 'fs-extra';
 import type { DatabaseConnectionCache } from '../database_connection_cache';
-import type { BatchAddRequestsResult, RequestQueueInfo} from '../emulators/request_queue_emulator';
+import type { BatchAddRequestsResult, RequestQueueInfo } from '../emulators/request_queue_emulator';
 import { RequestQueueEmulator } from '../emulators/request_queue_emulator';
 import { mapRawDataToRequestQueueInfo, purgeNullsFromObject, uniqueKeyToRequestId } from '../utils';
 import type { QueueOperationInfo } from '../emulators/queue_operation_info';
@@ -138,12 +138,15 @@ export class RequestQueueClient {
         return undefined;
     }
 
-    async update(newFields: { name?: string; }): Promise<RequestQueueInfo | undefined> {
+    async update(newFields: { name?: string }): Promise<RequestQueueInfo | undefined> {
         // The validation is intentionally loose to prevent issues
         // when swapping to a remote queue in production.
-        ow(newFields, ow.object.partialShape({
-            name: ow.optional.string.nonEmpty,
-        }));
+        ow(
+            newFields,
+            ow.object.partialShape({
+                name: ow.optional.string.nonEmpty,
+            }),
+        );
 
         if (!newFields.name) return;
 
@@ -176,13 +179,14 @@ export class RequestQueueClient {
     }
 
     async listHead(options: ListOptions = {}): Promise<QueueHead> {
-        ow(options, ow.object.exactShape({
-            limit: ow.optional.number,
-        }));
+        ow(
+            options,
+            ow.object.exactShape({
+                limit: ow.optional.number,
+            }),
+        );
 
-        const {
-            limit = 100,
-        } = options;
+        const { limit = 100 } = options;
 
         this._getEmulator().updateAccessedAtById(this.id);
         const requestJsons = this._getEmulator().selectRequestJsonsByQueueIdWithLimit(this.id, limit);
@@ -196,28 +200,42 @@ export class RequestQueueClient {
     }
 
     async addRequest(request: RequestModel, options: RequestOptions = {}): Promise<QueueOperationInfo> {
-        ow(request, ow.object.partialShape({
-            id: ow.undefined,
-            ...requestShape,
-        }));
+        ow(
+            request,
+            ow.object.partialShape({
+                id: ow.undefined,
+                ...requestShape,
+            }),
+        );
 
-        ow(options, ow.object.exactShape({
-            forefront: ow.optional.boolean,
-        }));
+        ow(
+            options,
+            ow.object.exactShape({
+                forefront: ow.optional.boolean,
+            }),
+        );
 
         const requestModel = this._createRequestModel(request, options.forefront);
         return this._getEmulator().addRequest(requestModel);
     }
 
     async batchAddRequests(requests: RequestModel[], options: RequestOptions = {}): Promise<BatchAddRequestsResult> {
-        ow(requests, ow.array.ofType(ow.object.partialShape({
-            id: ow.undefined,
-            ...requestShape,
-        })));
+        ow(
+            requests,
+            ow.array.ofType(
+                ow.object.partialShape({
+                    id: ow.undefined,
+                    ...requestShape,
+                }),
+            ),
+        );
 
-        ow(options, ow.object.exactShape({
-            forefront: ow.optional.boolean,
-        }));
+        ow(
+            options,
+            ow.object.exactShape({
+                forefront: ow.optional.boolean,
+            }),
+        );
 
         const requestModels = requests.map((request) => this._createRequestModel(request, options.forefront));
         return this._getEmulator().batchAddRequests(requestModels);
@@ -231,14 +249,20 @@ export class RequestQueueClient {
     }
 
     async updateRequest(request: RequestModel, options: RequestOptions = {}): Promise<QueueOperationInfo> {
-        ow(request, ow.object.partialShape({
-            id: ow.string,
-            ...requestShape,
-        }));
+        ow(
+            request,
+            ow.object.partialShape({
+                id: ow.string,
+                ...requestShape,
+            }),
+        );
 
-        ow(options, ow.object.exactShape({
-            forefront: ow.optional.boolean,
-        }));
+        ow(
+            options,
+            ow.object.exactShape({
+                forefront: ow.optional.boolean,
+            }),
+        );
 
         const requestModel = this._createRequestModel(request, options.forefront);
         return this._getEmulator().updateRequest(requestModel);
@@ -252,10 +276,13 @@ export class RequestQueueClient {
 
     async prolongRequestLock(id: string, options: ProlongRequestLockOptions): Promise<ProlongRequestLockResult> {
         ow(id, ow.string);
-        ow(options, ow.object.exactShape({
-            lockSecs: ow.number,
-            forefront: ow.optional.boolean,
-        }));
+        ow(
+            options,
+            ow.object.exactShape({
+                lockSecs: ow.number,
+                forefront: ow.optional.boolean,
+            }),
+        );
 
         this._getEmulator().updateAccessedAtById(this.id);
         const lockExpiresAt = this._getEmulator().prolongRequestLock(id, options);
@@ -265,24 +292,27 @@ export class RequestQueueClient {
 
     async deleteRequestLock(id: string, options: RequestOptions = {}) {
         ow(id, ow.string);
-        ow(options, ow.object.exactShape({
-            forefront: ow.optional.boolean,
-        }));
+        ow(
+            options,
+            ow.object.exactShape({
+                forefront: ow.optional.boolean,
+            }),
+        );
 
         this._getEmulator().updateAccessedAtById(this.id);
         this._getEmulator().deleteRequestLock(id, options);
     }
 
     async listAndLockHead(options: ListAndLockOptions): Promise<ListAndLockHeadResult> {
-        ow(options, ow.object.exactShape({
-            limit: ow.optional.number.lessThanOrEqual(25),
-            lockSecs: ow.number,
-        }));
+        ow(
+            options,
+            ow.object.exactShape({
+                limit: ow.optional.number.lessThanOrEqual(25),
+                lockSecs: ow.number,
+            }),
+        );
 
-        const {
-            limit = 25,
-            lockSecs,
-        } = options;
+        const { limit = 25, lockSecs } = options;
 
         this._getEmulator().updateAccessedAtById(this.id);
         const requestJsons = this._getEmulator().listAndLockHead(this.id, limit, lockSecs);

--- a/test/_globalSetup.ts
+++ b/test/_globalSetup.ts
@@ -4,4 +4,4 @@ import { TEMP_DIR } from './_tools';
 export default function globalSetup(): void {
     ensureDirSync(TEMP_DIR);
     emptyDirSync(TEMP_DIR);
-};
+}

--- a/test/_globalTeardown.ts
+++ b/test/_globalTeardown.ts
@@ -3,4 +3,4 @@ import { TEMP_DIR } from './_tools';
 
 export default function globalTeardown(): void {
     removeSync(TEMP_DIR);
-};
+}

--- a/test/_tools.ts
+++ b/test/_tools.ts
@@ -9,9 +9,9 @@ export function prepareTestDir(): string {
     ensureDirSync(dir);
     emptyDirSync(dir);
     return dir;
-};
+}
 
 export function removeTestDir(name: string): void {
     const dir = join(TEMP_DIR, name);
     removeSync(dir);
-};
+}

--- a/test/datasets.test.ts
+++ b/test/datasets.test.ts
@@ -223,17 +223,16 @@ describe('pushItems', () => {
         });
 
         test('when individual items are arrays', async () => {
-            const arrayOfArrays = [
-                { foo: 'bar' },
-                [{ one: 1 }, { two: 2 }],
-            ];
+            const arrayOfArrays = [{ foo: 'bar' }, [{ one: 1 }, { two: 2 }]];
 
             expect.hasAssertions();
             try {
                 // @ts-expect-error Making sure datasets only allow a single JSON object
                 await storageLocal.dataset(datasetName).pushItems(arrayOfArrays);
             } catch (err) {
-                expect(err.message).toMatch('Each dataset item can only be a single JSON object, not an array. Received:');
+                expect(err.message).toMatch(
+                    'Each dataset item can only be a single JSON object, not an array. Received:',
+                );
             }
         });
     });

--- a/test/request_queues.test.ts
+++ b/test/request_queues.test.ts
@@ -6,7 +6,7 @@ import { join } from 'node:path';
 import type { Database, Statement } from 'better-sqlite3';
 import { ApifyStorageLocal } from '../src/index';
 import { STORAGE_NAMES, DATABASE_FILE_NAME } from '../src/consts';
-import type { BatchAddRequestsResult} from '../src/emulators/request_queue_emulator';
+import type { BatchAddRequestsResult } from '../src/emulators/request_queue_emulator';
 import { RequestQueueEmulator } from '../src/emulators/request_queue_emulator';
 import { uniqueKeyToRequestId } from '../src/utils';
 import { prepareTestDir, removeTestDir } from './_tools';
@@ -14,9 +14,10 @@ import type { DatabaseConnectionCache } from '../src/database_connection_cache';
 import type { RequestModel } from '../src/resource_clients/request_queue';
 
 // TODO: switch to timers/promises when targeting Node.js 16
-const setTimeout = (ms = 1) => new Promise((resolve) => {
-    nativeSetTimeout(resolve, ms);
-});
+const setTimeout = (ms = 1) =>
+    new Promise((resolve) => {
+        nativeSetTimeout(resolve, ms);
+    });
 
 const REQUESTS_TABLE_NAME = `${STORAGE_NAMES.REQUEST_QUEUES}_requests`;
 
@@ -96,19 +97,23 @@ describe('sanity checks for seeded data', () => {
     Object.values(TEST_QUEUES).forEach((queue) => {
         test('queues table exists', () => {
             const db = queueNameToDb(queue.name);
-            const { name } = db.prepare(`
+            const { name } = db
+                .prepare(`
                 SELECT name FROM sqlite_master
                 WHERE type='table' AND name='${STORAGE_NAMES.REQUEST_QUEUES}';
-            `).get() as any;
+            `)
+                .get() as any;
             expect(name).toBe(STORAGE_NAMES.REQUEST_QUEUES);
         });
 
         test('requests table exists', () => {
             const db = queueNameToDb(queue.name);
-            const { name } = db.prepare(`
+            const { name } = db
+                .prepare(`
                 SELECT name FROM sqlite_master
                 WHERE type='table' AND name='${REQUESTS_TABLE_NAME}';
-            `).get() as any;
+            `)
+                .get() as any;
             expect(name).toBe(REQUESTS_TABLE_NAME);
         });
 
@@ -143,11 +148,13 @@ describe('timestamps:', () => {
         const beforeUpdate = selectTimestamps.get() as any;
         const request = numToRequest(1);
         await setTimeout(1);
-        db.prepare(`
+        db
+            .prepare(`
             UPDATE ${REQUESTS_TABLE_NAME}
             SET retryCount = 10
             WHERE queueId = ${QUEUE_ID} AND id = ?
-        `).run(request.id) as any;
+        `)
+            .run(request.id) as any;
         const afterUpdate = selectTimestamps.get() as any;
         expect(new Date(afterUpdate.modifiedAt).getTime()).toBeGreaterThan(new Date(beforeUpdate.modifiedAt).getTime());
         expect(new Date(afterUpdate.accessedAt).getTime()).toBeGreaterThan(new Date(beforeUpdate.accessedAt).getTime());
@@ -172,10 +179,12 @@ describe('timestamps:', () => {
         const beforeUpdate = selectTimestamps.get() as any;
         const request = numToRequest(1);
         await setTimeout(1);
-        db.prepare(`
+        db
+            .prepare(`
             DELETE FROM ${REQUESTS_TABLE_NAME}
             WHERE queueId = ${QUEUE_ID} AND id = ?
-        `).run(request.id) as any;
+        `)
+            .run(request.id) as any;
         const afterUpdate = selectTimestamps.get() as any;
         expect(new Date(afterUpdate.modifiedAt).getTime()).toBeGreaterThan(new Date(beforeUpdate.modifiedAt).getTime());
         expect(new Date(afterUpdate.accessedAt).getTime()).toBeGreaterThan(new Date(beforeUpdate.accessedAt).getTime());
@@ -303,17 +312,11 @@ describe('request counts:', () => {
     });
 
     /* eslint-disable @typescript-eslint/no-empty-function */
-    test.skip('deleting a request decrements totalRequestCount', async () => {
+    test.skip('deleting a request decrements totalRequestCount', async () => {});
 
-    });
+    test.skip('deleting a handled request decrements handledRequestCount', async () => {});
 
-    test.skip('deleting a handled request decrements handledRequestCount', async () => {
-
-    });
-
-    test.skip('deleting an pending request does not decrement handledRequestCount', async () => {
-
-    });
+    test.skip('deleting an pending request does not decrement handledRequestCount', async () => {});
     /* eslint-enable @typescript-eslint/no-empty-function */
 });
 
@@ -386,10 +389,12 @@ describe('addRequest', () => {
         });
         expect(counter.requests(queueName)).toBe(startCount + 1);
 
-        const requestModel = db.prepare(`
+        const requestModel = db
+            .prepare(`
             SELECT * FROM ${REQUESTS_TABLE_NAME}
             WHERE queueId = ${QUEUE_ID} AND id = ?
-        `).get(newRequestId) as any;
+        `)
+            .get(newRequestId) as any;
         expect(requestModel.queueId).toBe(QUEUE_ID);
         expect(requestModel.id).toBe(newRequestId);
         expect(requestModel.url).toBe(newRequest.url);
@@ -421,10 +426,12 @@ describe('addRequest', () => {
         } as const;
 
         await storageLocal.requestQueue(queueName).addRequest(newRequest);
-        const requestModel = db.prepare(`
+        const requestModel = db
+            .prepare(`
             SELECT * FROM ${REQUESTS_TABLE_NAME}
             WHERE queueId = ${QUEUE_ID} AND id = ?
-        `).get(requestId) as any;
+        `)
+            .get(requestId) as any;
         expect(requestModel.id).toBe(requestId);
         expect(requestModel.method).toBe('GET');
         expect(typeof requestModel.orderNo).toBe('number');
@@ -465,11 +472,14 @@ describe('addRequest', () => {
 
         await storageLocal.requestQueue(queueName).addRequest(newRequest, { forefront: true });
         expect(counter.requests(queueName)).toBe(startCount + 1);
-        const firstId = db.prepare(`
+        const firstId = db
+            .prepare(`
             SELECT id FROM ${REQUESTS_TABLE_NAME}
             WHERE queueId = ${QUEUE_ID} AND orderNo IS NOT NULL
             LIMIT 1
-        `).pluck().get();
+        `)
+            .pluck()
+            .get();
         expect(firstId).toBe(newRequestId);
     });
 
@@ -544,7 +554,9 @@ describe('batchAddRequests', () => {
         const newRequestId2 = newRequest2.id!;
         newRequest2.id = undefined;
 
-        const queueOperationInfo = await storageLocal.requestQueue(queueName).batchAddRequests([newRequest1, newRequest2]);
+        const queueOperationInfo = await storageLocal
+            .requestQueue(queueName)
+            .batchAddRequests([newRequest1, newRequest2]);
         expect(queueOperationInfo).toEqual<BatchAddRequestsResult>({
             processedRequests: [
                 {
@@ -564,10 +576,12 @@ describe('batchAddRequests', () => {
         });
         expect(counter.requests(queueName)).toBe(startCount + 2);
 
-        const requestModel1 = db.prepare(`
+        const requestModel1 = db
+            .prepare(`
             SELECT * FROM ${REQUESTS_TABLE_NAME}
             WHERE queueId = ${QUEUE_ID} AND id = ?
-        `).get(newRequestId1) as any;
+        `)
+            .get(newRequestId1) as any;
         expect(requestModel1.queueId).toBe(QUEUE_ID);
         expect(requestModel1.id).toBe(newRequestId1);
         expect(requestModel1.url).toBe(newRequest1.url);
@@ -580,10 +594,12 @@ describe('batchAddRequests', () => {
         expect(savedRequest1.id).toBe(newRequestId1);
         expect(savedRequest1).toMatchObject({ ...newRequest1, id: newRequestId1 });
 
-        const requestModel2 = db.prepare(`
+        const requestModel2 = db
+            .prepare(`
             SELECT * FROM ${REQUESTS_TABLE_NAME}
             WHERE queueId = ${QUEUE_ID} AND id = ?
-        `).get(newRequestId2) as any;
+        `)
+            .get(newRequestId2) as any;
         expect(requestModel2.queueId).toBe(QUEUE_ID);
         expect(requestModel2.id).toBe(newRequestId2);
         expect(requestModel2.url).toBe(newRequest2.url);
@@ -600,12 +616,14 @@ describe('batchAddRequests', () => {
     test('succeeds when request is already present', async () => {
         const queueOperationInfo = await storageLocal.requestQueue(queueName).batchAddRequests([request]);
         expect(queueOperationInfo).toEqual<BatchAddRequestsResult>({
-            processedRequests: [{
-                requestId: uniqueKeyToRequestId(request.url),
-                uniqueKey: request.uniqueKey,
-                wasAlreadyHandled: false,
-                wasAlreadyPresent: true,
-            }],
+            processedRequests: [
+                {
+                    requestId: uniqueKeyToRequestId(request.url),
+                    uniqueKey: request.uniqueKey,
+                    wasAlreadyHandled: false,
+                    wasAlreadyPresent: true,
+                },
+            ],
             unprocessedRequests: [],
         });
         expect(counter.requests(queueName)).toBe(startCount);
@@ -619,10 +637,12 @@ describe('batchAddRequests', () => {
         } as const;
 
         await storageLocal.requestQueue(queueName).batchAddRequests([newRequest]);
-        const requestModel = db.prepare(`
+        const requestModel = db
+            .prepare(`
             SELECT * FROM ${REQUESTS_TABLE_NAME}
             WHERE queueId = ${QUEUE_ID} AND id = ?
-        `).get(requestId) as any;
+        `)
+            .get(requestId) as any;
         expect(requestModel.id).toBe(requestId);
         expect(requestModel.method).toBe('GET');
         expect(typeof requestModel.orderNo).toBe('number');
@@ -637,12 +657,14 @@ describe('batchAddRequests', () => {
 
         const queueOperationInfo = await storageLocal.requestQueue(queueName).batchAddRequests([request]);
         expect(queueOperationInfo).toEqual<BatchAddRequestsResult>({
-            processedRequests: [{
-                requestId: uniqueKeyToRequestId(request.url),
-                uniqueKey: request.uniqueKey,
-                wasAlreadyHandled: true,
-                wasAlreadyPresent: true,
-            }],
+            processedRequests: [
+                {
+                    requestId: uniqueKeyToRequestId(request.url),
+                    uniqueKey: request.uniqueKey,
+                    wasAlreadyHandled: true,
+                    wasAlreadyPresent: true,
+                },
+            ],
             unprocessedRequests: [],
         });
         expect(counter.requests(queueName)).toBe(startCount);
@@ -653,12 +675,14 @@ describe('batchAddRequests', () => {
 
         const queueOperationInfo = await storageLocal.requestQueue(queueName).batchAddRequests([request]);
         expect(queueOperationInfo).toEqual<BatchAddRequestsResult>({
-            processedRequests: [{
-                requestId: uniqueKeyToRequestId(request.url),
-                uniqueKey: request.uniqueKey,
-                wasAlreadyHandled: false,
-                wasAlreadyPresent: true,
-            }],
+            processedRequests: [
+                {
+                    requestId: uniqueKeyToRequestId(request.url),
+                    uniqueKey: request.uniqueKey,
+                    wasAlreadyHandled: false,
+                    wasAlreadyPresent: true,
+                },
+            ],
             unprocessedRequests: [],
         });
         expect(counter.requests(queueName)).toBe(startCount);
@@ -674,11 +698,14 @@ describe('batchAddRequests', () => {
 
         await storageLocal.requestQueue(queueName).batchAddRequests([newRequest1, newRequest2], { forefront: true });
         expect(counter.requests(queueName)).toBe(startCount + 2);
-        const firstId = db.prepare(`
+        const firstId = db
+            .prepare(`
             SELECT id FROM ${REQUESTS_TABLE_NAME}
             WHERE queueId = ${QUEUE_ID} AND orderNo IS NOT NULL
             LIMIT 1
-        `).pluck().get();
+        `)
+            .pluck()
+            .get();
         expect(firstId).toBe(newRequestId1);
     });
 
@@ -792,10 +819,12 @@ describe('updateRequest', () => {
             wasAlreadyHandled: false,
         });
 
-        const requestModel = db.prepare(`
+        const requestModel = db
+            .prepare(`
             SELECT * FROM ${REQUESTS_TABLE_NAME}
             WHERE queueId = ${QUEUE_ID} AND id = ?
-        `).get(request.id) as any;
+        `)
+            .get(request.id) as any;
 
         expect(requestModel.method).toBe(method);
         expect(requestModel.retryCount).toBe(retryCount);
@@ -843,11 +872,14 @@ describe('updateRequest', () => {
     test('forefront moves request to queue head', async () => {
         await storageLocal.requestQueue(queueName).updateRequest(request, { forefront: true });
         expect(counter.requests(queueName)).toBe(startCount);
-        const requestId = db.prepare(`
+        const requestId = db
+            .prepare(`
             SELECT id FROM ${REQUESTS_TABLE_NAME}
             WHERE queueId = ${QUEUE_ID} AND orderNo IS NOT NULL
             LIMIT 1
-        `).pluck().get();
+        `)
+            .pluck()
+            .get();
         expect(requestId).toBe(request.id);
     });
 
@@ -905,10 +937,12 @@ describe.skip('deleteRequest', () => {
 
     test('deletes request', async () => {
         await storageLocal.requestQueue(queueName).deleteRequest(request.id!);
-        const requestModel = db.prepare(`
+        const requestModel = db
+            .prepare(`
             SELECT * FROM ${REQUESTS_TABLE_NAME}
             WHERE queueId = ${QUEUE_ID} AND id = ?
-        `).get(request.id);
+        `)
+            .get(request.id);
         expect(requestModel).toBeUndefined();
         expect(counter.requests(queueName)).toBe(startCount - 1);
     });
@@ -943,9 +977,7 @@ describe('listHead', () => {
 
     test('fetches requests in correct order', async () => {
         const models = createRequestModels(queueName, startCount);
-        const expectedItems = models
-            .sort((a, b) => a.orderNo - b.orderNo)
-            .map((m) => JSON.parse(m.json));
+        const expectedItems = models.sort((a, b) => a.orderNo - b.orderNo).map((m) => JSON.parse(m.json));
 
         const { items } = await storageLocal.requestQueue(queueName).listHead();
         expect(items).toEqual(expectedItems);
@@ -990,7 +1022,7 @@ describe('listHead', () => {
 describe('RequestQueue v2', () => {
     const totalRequestsPerTest = 50;
 
-    function calculateHistogram(requests: { uniqueKey: string }[]) : number[] {
+    function calculateHistogram(requests: { uniqueKey: string }[]): number[] {
         const histogram: number[] = [];
         for (const item of requests) {
             const key = item.uniqueKey;
@@ -1086,10 +1118,12 @@ function seed(requestQueuesDir: string, dbConnections: DatabaseConnectionCache) 
 }
 
 function insertQueue(db: Database, queue: TestQueue) {
-    return db.prepare(`
+    return db
+        .prepare(`
         INSERT INTO ${STORAGE_NAMES.REQUEST_QUEUES}(name, totalRequestCount)
         VALUES(?, ?)
-    `).run(queue.name, queue.requestCount).lastInsertRowid as number;
+    `)
+        .run(queue.name, queue.requestCount).lastInsertRowid as number;
 }
 
 function insertRequests(db: Database, models: RequestModel[]) {
@@ -1145,7 +1179,9 @@ function createCounter(requestQueuesDir: string, dbConnections: DatabaseConnecti
                     queueDir: join(requestQueuesDir, queueName),
                     dbConnections,
                 });
-                const selectQueueCount = emulator.db.prepare(`SELECT COUNT(*) FROM ${STORAGE_NAMES.REQUEST_QUEUES}`).pluck();
+                const selectQueueCount = emulator.db
+                    .prepare(`SELECT COUNT(*) FROM ${STORAGE_NAMES.REQUEST_QUEUES}`)
+                    .pluck();
                 const queuesInDb = selectQueueCount.get();
                 if (queuesInDb !== 1) throw new Error('We have a queue database with more than 1 queue.');
                 count++;
@@ -1155,7 +1191,9 @@ function createCounter(requestQueuesDir: string, dbConnections: DatabaseConnecti
         requests(queueName: string) {
             const queueDir = join(requestQueuesDir, queueName);
             const emulator = new RequestQueueEmulator({ queueDir, dbConnections });
-            const selectRequestCount = emulator.db.prepare(`SELECT COUNT(*) FROM ${REQUESTS_TABLE_NAME} WHERE queueId = ${QUEUE_ID}`).pluck();
+            const selectRequestCount = emulator.db
+                .prepare(`SELECT COUNT(*) FROM ${REQUESTS_TABLE_NAME} WHERE queueId = ${QUEUE_ID}`)
+                .pluck();
             return selectRequestCount.get();
         },
     };


### PR DESCRIPTION
## Summary

Adds the `oxfmt` (Rust prettier-style formatter from oxc-project) as a follow-up to the oxlint migration in #70.

Single PR (no tooling/reformat split) since the repo is small — only 23 source files. Designed to be added to `.git-blame-ignore-revs` after merge.

## Changes

- **`.oxfmtrc.json`** — config matches existing code style (`tabWidth: 4`, `singleQuote: true`, `printWidth: 120`, `trailingComma: 'all'`).
- **Scripts** — adds `pnpm format` (`oxfmt`) and `pnpm format:check` (`oxfmt --check`).
- **devDep** — adds `oxfmt: 0.46.0`.
- **Mass reformat** — `oxfmt --write .` applied across `src/`, `test/`, `scripts/`, root config files. Mostly multi-line splitting of long imports / function signatures previously kept on a single line.
- **CI** — new `format-check` job runs `pnpm format:check` on every PR.

## Test plan

- [x] `pnpm format:check` clean
- [x] `pnpm lint` clean (0 errors, 34 warnings — same as base)
- [x] `pnpm test` passes (132 passed, 6 skipped)
- [x] `pnpm build` clean
- [ ] Add `.git-blame-ignore-revs` after merge with the squash commit's SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)