### PR TITLE
chore: drop redundant oxfmt options that .editorconfig already provides

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,4 @@ insert_final_newline = true
 end_of_line = lf
 # editorconfig-tools is unable to ignore longs strings or urls
 max_line_length = null
+quote_type = single

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,7 +1,4 @@
 {
-    "tabWidth": 4,
-    "singleQuote": true,
-    "trailingComma": "all",
     "printWidth": 120,
     "ignorePatterns": [
         "**/*.md",


### PR DESCRIPTION
## Summary

oxfmt reads `.editorconfig`, so `tabWidth` / `singleQuote` in `.oxfmtrc.json` were duplicating settings.

This PR:
- Adds `quote_type = single` to `.editorconfig` (it already had `indent_size = 4`)
- Drops `tabWidth` and `singleQuote` from `.oxfmtrc.json`
- Drops `trailingComma: "all"` since [it's the default](https://oxc.rs/docs/guide/usage/formatter/config-file-reference.html#trailingcomma)

`printWidth` stays in `.oxfmtrc.json` (no editorconfig equivalent we want to enforce).

`pnpm format:check` is still clean — no actual file changes, just config consolidation.