### PR TITLE
chore: enforce pnpm via devEngines (onFail:warn)

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,5 +80,12 @@
         "typescript": "6.0.3",
         "vitest": "^4.1.5"
     },
-    "packageManager": "pnpm@10.33.2"
+    "packageManager": "pnpm@10.33.4",
+    "devEngines": {
+        "packageManager": {
+            "name": "pnpm",
+            "version": "10.33.4",
+            "onFail": "warn"
+        }
+    }
 }


### PR DESCRIPTION
This repo doesn't ship a preinstall enforcement script, but adding `devEngines.packageManager` (`onFail: "warn"`) brings it in line with the rest of the public pnpm repos and gives local devs the visible "use pnpm" signal when they run npm against the repo.

`onFail: "warn"` (not `error`) avoids tripping CI steps that indirectly invoke npm — pnpm v10 shells to npm for `pnpm version`, `pnpm config`, etc.

`devEngines` is only checked at the package's own repo root, never on transitive installs, so downstream consumers are unaffected.

Mirrors the rollout in apify/apify-client-js#895 + #896.