### PR TITLE
chore: Update actions from `apify/actions` [internal]

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -39,7 +39,7 @@ jobs:
                 with:
                     node-version: ${{ matrix.node-version }}
             -   name: Install pnpm and dependencies
-                uses: apify/actions/pnpm-install@v1.0.0
+                uses: apify/actions/pnpm-install@v1.1.0
             -   name: Run Tests
                 run: pnpm test
 
@@ -54,7 +54,7 @@ jobs:
                 with:
                     node-version: 24
             -   name: Install pnpm and dependencies
-                uses: apify/actions/pnpm-install@v1.0.0
+                uses: apify/actions/pnpm-install@v1.1.0
             -   run: pnpm lint
 
     format-check:
@@ -68,5 +68,5 @@ jobs:
                 with:
                     node-version: 24
             -   name: Install pnpm and dependencies
-                uses: apify/actions/pnpm-install@v1.0.0
+                uses: apify/actions/pnpm-install@v1.1.0
             -   run: pnpm format:check

--- a/.github/workflows/pre_release.yaml
+++ b/.github/workflows/pre_release.yaml
@@ -21,7 +21,7 @@ jobs:
             version_number: ${{ steps.release_metadata.outputs.version_number }}
             changelog: ${{ steps.release_metadata.outputs.changelog }}
         steps:
-            - uses: apify/actions/git-cliff-release@v1.0.0
+            - uses: apify/actions/git-cliff-release@v1.1.0
               name: Prepare release metadata
               id: release_metadata
               with:
@@ -58,7 +58,7 @@ jobs:
                   node-version: 24
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.0.0
+              uses: apify/actions/pnpm-install@v1.1.0
 
             - name: Update package version in package.json
               run: pnpm version --no-git-tag-version --allow-same-version ${{ needs.release_metadata.outputs.version_number }}
@@ -84,7 +84,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Execute publish workflow
-              uses: apify/actions/execute-workflow@v1.0.0
+              uses: apify/actions/execute-workflow@v1.1.0
               with:
                   workflow: publish_to_npm.yaml
                   inputs: '{ "ref": "${{ needs.update_changelog.outputs.changelog_commitish }}", "tag": "beta" }'

--- a/.github/workflows/publish_to_npm.yaml
+++ b/.github/workflows/publish_to_npm.yaml
@@ -34,7 +34,7 @@ jobs:
                   node-version: 24
                   registry-url: 'https://registry.npmjs.org'
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.0.0
+              uses: apify/actions/pnpm-install@v1.1.0
             - name: Check version consistency and bump pre-release version (beta only)
               if: ${{ inputs.tag == 'beta' }}
               run: node ./.github/scripts/before-beta-release.js

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
             changelog: ${{ steps.release_metadata.outputs.changelog }}
             release_notes: ${{ steps.release_metadata.outputs.release_notes }}
         steps:
-            - uses: apify/actions/git-cliff-release@v1.0.0
+            - uses: apify/actions/git-cliff-release@v1.1.0
               name: Prepare release metadata
               id: release_metadata
               with:
@@ -65,7 +65,7 @@ jobs:
                   node-version: 24
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.0.0
+              uses: apify/actions/pnpm-install@v1.1.0
 
             - name: Update package version in package.json
               run: pnpm version --no-git-tag-version --allow-same-version ${{ needs.release_metadata.outputs.version_number }}
@@ -106,7 +106,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Execute publish workflow
-              uses: apify/actions/execute-workflow@v1.0.0
+              uses: apify/actions/execute-workflow@v1.1.0
               with:
                   workflow: publish_to_npm.yaml
                   inputs: '{ "ref": "${{ needs.update_changelog.outputs.changelog_commitish }}", "tag": "latest" }'


### PR DESCRIPTION
There was an issue with the `v1.0.0` version of some of the actions from `apify/actions` (a NPM dependency was not present), I've released an updated version which fixes it.