### PR TITLE
chore: stop publishing broken declaration and source maps

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,7 +4,7 @@
         "allowSyntheticDefaultImports": true,
         "alwaysStrict": true,
         "declaration": true,
-        "declarationMap": true,
+        "declarationMap": false,
         "emitDecoratorMetadata": true,
         "esModuleInterop": true,
         "experimentalDecorators": true,
@@ -26,7 +26,7 @@
         "pretty": true,
         "removeComments": false,
         "resolveJsonModule": true,
-        "sourceMap": true,
+        "sourceMap": false,
         "strict": true,
         "target": "ES2022",
         "useDefineForClassFields": true


### PR DESCRIPTION
The published tarball excludes `src` but ships `.d.ts.map`/`.js.map` that reference `../src/*.ts`, so the maps never resolve — editors fall back to the compiled `.d.ts`/`.js` instead of the original source. Disabling `declarationMap`/`sourceMap` stops emitting these dead maps and shrinks the tarball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)